### PR TITLE
feat(collabs): Stage 8 Collaboration Board MVP — form, list, detail, hiring toggle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
+- Collaboration Board (Stage 8):
+  - Real CRUD with RLS; new fields (affiliated org, project types[], stage, looking_for with amount, contact, remarks, is_hiring).
+  - Pages: `/collaborations/new`, `/collaborations`, `/collaborations/[id]` with upvotes and threaded comments.
+  - Owner-only “Hiring/No longer hiring” toggle with optimistic UI; list hides closed by default.
+  - Project type chips; form re-ordered; Title ≤160.
+  - Docs updated: `docs/MVP_TECH_SPEC.md`, `docs/SERVER_ACTIONS.md`, `supabase/schema.md`.
+
+### Added
 - Stage 6 complete: comments with replies, upvotes (project/comment), optimistic UI, rate limits, and analytics events. Docs updated.
 
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -19,6 +19,16 @@ Data Flow (MVP)
   - Client components use thin wrappers in `web/lib/api/**` that call `/api/**` routes.
 - Contracts live in `docs/SERVER_ACTIONS.md` and `docs/MVP_TECH_SPEC.md`.
 
+Collaborations
+- Server module: `web/lib/server/collabs.ts` encapsulates DB access for collaborations (CRUD, tag joins, upvote toggle, threaded comments, hiring toggle).
+- Server actions: `web/app/collaborations/actions.ts` provides typed endpoints for client components (`createCollabAction`, `updateCollabAction`, `deleteCollabAction`, `toggleCollabUpvoteAction`, `addCollabCommentAction`, `deleteCollabCommentAction`).
+- Pages:
+  - `/collaborations` (server): calls `listCollabs` directly and renders project type chips; defaults to `is_hiring=true`.
+  - `/collaborations/new` (client): server action form for creation; DB tags via `useTags()`.
+  - `/collaborations/[id]` (server): calls `getCollab`; renders owner-only hiring toggle (client) and threaded comments.
+- Auth & RLS: all writes require authenticated Supabase session; RLS enforces owner-only writes and public reads for non-deleted rows. Hiring toggle updates `is_hiring` under owner session.
+- Optimistic UI: upvote button and hiring toggle perform optimistic updates with rollback on server error; comments add/delete also use optimistic flows.
+
 Projects (Stage 5)
 - Implemented: `createProject`, `listProjects`, `getProject` in `web/lib/server/projects.ts` with Zod validation in `web/app/projects/schema.ts` and a server action `web/app/projects/actions.ts` for creation.
 - Listing:

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -23,8 +23,8 @@ Implemented (Stage 5)
 - getProject: Implemented. Returns project, tags grouped by type, owner display name, and `upvoteCount`. Comments updated in Stage 6.
 
 Locations
-- Server: `web/lib/server/projects.ts`
-- Server actions: `web/app/projects/actions.ts` (`createProjectAction`, `addCommentAction`, `deleteCommentAction`, `addReplyAction`, `toggleProjectUpvoteAction`, `toggleCommentUpvoteAction`)
+- Projects server: `web/lib/server/projects.ts`; actions: `web/app/projects/actions.ts` (`createProjectAction`, `addCommentAction`, `deleteCommentAction`, `addReplyAction`, `toggleProjectUpvoteAction`, `toggleCommentUpvoteAction`)
+- Collaborations server: `web/lib/server/collabs.ts`; actions: `web/app/collaborations/actions.ts`
 
 Comments
 - addComment(projectId, body 1–1000): `-> { id }`
@@ -39,9 +39,14 @@ Rate limits (server-enforced)
 - Server actions surface a friendly `formError` and include `retryAfterSec` for UI cooldown messaging.
 
 Collaborations
-- createCollab(input): `{ kind, title, description, skills[], region?, commitment? } -> { id }`
-- listCollabs(params): `{ cursor?, limit=20, q?, kind?, skills? } -> { items[], nextCursor? }`
-- getCollab(id), updateCollab(id, fields), deleteCollab(id): owner-only modifies
+- createCollab(input): `{ title≤160, affiliatedOrg?, projectTypes[], description 1–4000, stage, lookingFor[1..5]{ role, amount(1..99), prerequisite≤400, goodToHave≤400, description≤1200 }, contact≤200, remarks≤1000, techTagIds[], categoryTagIds[] } -> { id } | validation_error`
+- listCollabs(params): `{ cursor?, limit=20, kind?, skills?, includeClosed? } -> { items[], nextCursor? }` (defaults to `is_hiring=true`)
+- getCollab(id): `-> { collaboration, tags, owner, upvoteCount, hasUserUpvoted, comments }`
+- updateCollab(id, fields): owner-only, fields optional: `{ title?, affiliatedOrg?, description?, stage?, lookingFor?, contact?, remarks?, isHiring? } -> { ok: true } | validation_error`
+- deleteCollab(id): owner-only `-> { ok: true }`
+- toggleCollabUpvote(collaborationId): `-> { ok: true, upvoted: boolean } | { error: 'unauthorized'|'rate_limited' }`
+- addCollabComment(collaborationId, body 1–1000, parentCommentId?): `-> { id } | { error }`
+- deleteCollabComment(commentId): `-> { ok: true } | { error }`
 
 Validation (UX)
 - Respect limits: Title ≤80, Tagline ≤140, Description ≤4000; URLs must be `http/https`.

--- a/docs/UI_PATTERNS.md
+++ b/docs/UI_PATTERNS.md
@@ -1,0 +1,69 @@
+# UI Patterns
+
+Purpose: Concise, reusable UI patterns used across the MVP. Keep this scoped to interaction and presentation conventions, not API or schema design.
+
+## Optimistic UI
+
+- Upvotes (projects, comments, collaborations)
+  - Maintain a click lock to avoid concurrent toggles.
+  - Derive a stable baseCount: `initialCount - (hasUserUpvoted ? 1 : 0)`.
+  - Optimistically set `displayCount = baseCount + (optimisticUpvoted ? 1 : 0)`.
+  - On server response, reconcile the optimistic flag; on error, revert and show a toast.
+
+- Hiring toggle (collaborations)
+  - Owner-only button with optimistic flip.
+  - Use `useActionState(updateCollabAction)` and wrap the call in `startTransition(() => formAction(fd))`.
+  - Keep `localHiring` state; store previous state in a ref for rollback on error.
+  - Non-owners see a read-only badge that mirrors current status.
+
+## Comment Threads
+
+- Ordering
+  - Top-level comments: newest → oldest.
+  - Replies: oldest → newest (one level deep).
+
+- Rules
+  - Only authors can delete their own comments; deletion is permanent within MVP (no edit flow).
+  - Reply parent must belong to the same collaboration/project and be a top-level comment.
+
+## Badges and Chips
+
+- Project Types (collaborations)
+  - Outline chips with human labels (via `formatProjectType`).
+
+- Hiring Status (collaborations)
+  - Hiring: black background, white text, solid border.
+  - No longer hiring: white background, gray text, outlined border.
+
+## Character Counters and Limits
+
+- Counters appear to the right of field labels or in compact helper text below inputs.
+- Typical limits
+  - Title: 160 characters (projects, collaborations).
+  - Roles Hiring
+    - Amount: 1–99
+    - Prerequisite: ≤400
+    - Good to have: ≤400
+    - Description: ≤1200
+  - Project Description: ≤4000
+  - Contact: ≤200; Remarks: ≤1000
+
+## Server Actions from Client Components
+
+- Use `useActionState` or `useFormState` to bind server actions.
+- Call returned functions inside a transition: `startTransition(() => formAction(fd))`.
+- Do not pass server functions directly as props to client components.
+- Prefer server action forms for authenticated writes (sets cookies/session properly on server).
+
+## Accessibility and Status
+
+- Buttons indicate pending state via `disabled` and visual feedback.
+- Error messages use toasts and/or inline messages near the control.
+- Badges and chips include accessible text; avoid communicating state by color alone.
+
+## References
+
+- Contracts: `docs/SERVER_ACTIONS.md`
+- Data & RLS: `supabase/schema.md`
+- Architecture: `docs/ARCHITECTURE.md`
+- Tech Spec: `docs/MVP_TECH_SPEC.md`

--- a/supabase/migrations/20250825120000_extend_collaborations_add_tags_upvotes_comments.sql
+++ b/supabase/migrations/20250825120000_extend_collaborations_add_tags_upvotes_comments.sql
@@ -1,0 +1,78 @@
+-- Stage 8: Collaboration board — extended schema
+
+-- 1) Extend collaborations with additional fields
+alter table if exists collaborations
+  add column if not exists affiliated_org text,
+  add column if not exists project_type text,
+  add column if not exists stage text,
+  add column if not exists looking_for jsonb not null default '[]'::jsonb,
+  add column if not exists contact text,
+  add column if not exists remarks text;
+
+-- Project type and stage validations (allow NULL but restrict values when present)
+do $$ begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'collaborations_project_type_valid'
+  ) then
+    alter table collaborations add constraint collaborations_project_type_valid
+      check (
+        project_type is null or project_type in (
+          'personal','open_source','research','startup_idea_validation','startup_registered',
+          'student_organization','university','ngo','corporate','others'
+        )
+      );
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_constraint
+    where conname = 'collaborations_stage_valid'
+  ) then
+    alter table collaborations add constraint collaborations_stage_valid
+      check (
+        stage is null or stage in (
+          'ideation','planning','requirements_analysis','design','mvp_development',
+          'testing_validation','implementation_deployment','monitoring_maintenance',
+          'evaluation_closure','scaling','adding_features'
+        )
+      );
+  end if;
+end $$;
+
+-- Helpful created_at index (if missing)
+create index if not exists idx_collaborations_created_at on collaborations (created_at desc);
+
+-- 2) Collaboration ↔ Tags (many-to-many)
+create table if not exists collaboration_tags (
+  collaboration_id uuid references collaborations(id) on delete cascade,
+  tag_id int references tags(id) on delete cascade,
+  primary key (collaboration_id, tag_id)
+);
+
+create index if not exists idx_collaboration_tags_tag on collaboration_tags (tag_id, collaboration_id);
+
+-- 3) Collaboration upvotes (1 per user per collaboration)
+create table if not exists collaboration_upvotes (
+  collaboration_id uuid references collaborations(id) on delete cascade,
+  user_id uuid references auth.users(id) on delete cascade,
+  created_at timestamptz not null default now(),
+  primary key (collaboration_id, user_id)
+);
+
+create index if not exists idx_collaboration_upvotes_collab on collaboration_upvotes (collaboration_id);
+
+-- 4) Collaboration comments (top-level only for MVP)
+create table if not exists collab_comments (
+  id uuid primary key default gen_random_uuid(),
+  collaboration_id uuid references collaborations(id) on delete cascade,
+  author_id uuid references auth.users(id) on delete cascade,
+  body text not null check (char_length(body) between 1 and 1000),
+  soft_deleted boolean not null default false,
+  created_at timestamptz not null default now()
+);
+
+create index if not exists idx_collab_comments_collab_created on collab_comments (collaboration_id, created_at desc);
+
+

--- a/supabase/migrations/20250825121500_add_collab_comment_replies.sql
+++ b/supabase/migrations/20250825121500_add_collab_comment_replies.sql
@@ -1,0 +1,9 @@
+-- Add 1-level reply support for collaboration comments
+
+alter table if exists collab_comments
+  add column if not exists parent_comment_id uuid references collab_comments(id) on delete cascade;
+
+create index if not exists idx_collab_comments_parent_created on collab_comments (parent_comment_id, created_at asc);
+
+
+

--- a/supabase/migrations/20250825123000_collab_project_types_is_hiring.sql
+++ b/supabase/migrations/20250825123000_collab_project_types_is_hiring.sql
@@ -1,0 +1,15 @@
+-- Add multi project types and hiring state to collaborations
+
+alter table if exists collaborations
+  add column if not exists project_types text[],
+  add column if not exists is_hiring boolean not null default true;
+
+-- Backfill project_types from legacy project_type if present
+update collaborations
+set project_types = array[project_type]
+where project_types is null and project_type is not null;
+
+-- Helpful partial index to list open roles fast
+create index if not exists idx_collaborations_is_hiring on collaborations (is_hiring) where is_hiring = true;
+
+

--- a/supabase/schema.md
+++ b/supabase/schema.md
@@ -13,7 +13,7 @@ Tables
 - project_upvotes(project_id FK, user_id FK, created_at) — PK(project_id, user_id)
  - comment_upvotes(comment_id FK, user_id FK, created_at) — PK(comment_id, user_id)
  - rate_limits(action, user_id, window_start, count) — simple per-user windowed counter
-- collaborations(id PK, owner_id FK, kind, title, description, skills[], region, commitment, soft_deleted, created_at)
+- collaborations(id PK, owner_id FK, kind, title, description, affiliated_org, project_types text[], stage, looking_for jsonb, contact, remarks, is_hiring boolean, soft_deleted, created_at)
 
 Relationships
 - profiles 1:1 auth.users
@@ -43,5 +43,5 @@ Notes (Stage 3 Profiles)
 - projects: select soft_deleted=false; insert/update/delete only owner
 - comments: select soft_deleted=false; insert only author; delete only author
 - project_upvotes: select all; insert/delete only same user
-- collaborations: select soft_deleted=false; insert/update/delete only owner
+- collaborations: select soft_deleted=false; insert/update/delete only owner; `is_hiring` controls default list visibility
 

--- a/web/app/collaborations/[id]/page.tsx
+++ b/web/app/collaborations/[id]/page.tsx
@@ -2,14 +2,24 @@ import type { Metadata } from "next"
 import { notFound } from "next/navigation"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
-import { getCollab } from "@/lib/api/mockCollabs"
+import { getCollab } from "@/lib/server/collabs"
+import { getServerSupabase } from "@/lib/supabaseServer"
+import { toggleCollabUpvoteAction, addCollabCommentAction, deleteCollabCommentAction } from "@/app/collaborations/actions"
+import { CollabUpvoteButton } from "@/components/features/collaborations/collab-upvote-button"
+import { CollabCommentForm } from "@/components/features/collaborations/collab-comment-form"
+import { CollabCommentList } from "@/components/features/collaborations/collab-comment-list"
+import { RoleCard } from "@/components/features/collaborations/role-card"
+import { HiringToggle } from "@/components/features/collaborations/hiring-toggle"
+import { updateCollabAction } from "@/app/collaborations/actions"
+import { formatStage, formatProjectType } from "@/lib/collabs/options"
 
 interface CollabDetailPageProps {
   params: { id: string }
 }
 
 export async function generateMetadata({ params }: CollabDetailPageProps): Promise<Metadata> {
-  const collab = await getCollab(params.id)
+  const p = await params
+  const collab = await getCollab(p.id)
 
   if (!collab) {
     return {
@@ -18,17 +28,22 @@ export async function generateMetadata({ params }: CollabDetailPageProps): Promi
   }
 
   return {
-    title: `${collab.title} - Builder's Pub`,
-    description: collab.description,
+    title: `${collab.collaboration.title} - Builder's Pub`,
+    description: collab.collaboration.description,
   }
 }
 
 export default async function CollabDetailPage({ params }: CollabDetailPageProps) {
-  const collab = await getCollab(params.id)
+  const p = await params
+  const item = await getCollab(p.id)
 
-  if (!collab) {
+  if (!item) {
     notFound()
   }
+
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  const isOwner = !!auth.user && auth.user.id === item.collaboration.ownerId
 
   return (
     <div className="max-w-4xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -38,55 +53,92 @@ export default async function CollabDetailPage({ params }: CollabDetailPageProps
           <div className="flex items-start justify-between mb-4">
             <div className="flex-1">
               <div className="flex items-center gap-3 mb-3">
-                <Badge variant="outline" className="capitalize">
-                  {collab.kind}
-                </Badge>
-                <span className="text-sm text-gray-500">
-                  Posted by {collab.owner.displayName} on {collab.createdAt.toLocaleDateString()}
-                </span>
+                <span className="text-sm text-gray-500">Posted by {item.owner.displayName} on {item.collaboration.createdAt.toLocaleDateString?.() || new Date(item.collaboration.createdAt as any).toLocaleDateString()}</span>
               </div>
 
-              <h1 className="text-3xl font-bold text-gray-900 mb-4">{collab.title}</h1>
+              <h1 className="text-3xl font-bold text-gray-900 mb-4">{item.collaboration.title}</h1>
 
-              <div className="grid grid-cols-1 md:grid-cols-3 gap-4 text-sm">
-                {collab.region && (
-                  <div>
-                    <span className="font-medium text-gray-700">Location:</span>
-                    <span className="ml-2 text-gray-600">{collab.region}</span>
+              <div className="space-y-2 text-sm">
+                {item.collaboration.affiliatedOrg && (
+                  <div className="flex items-baseline gap-2 overflow-hidden">
+                    <span className="font-medium text-gray-700 whitespace-nowrap">Affiliated Organisation:</span>
+                    <span className="text-gray-600 truncate min-w-0">{item.collaboration.affiliatedOrg.replace(/\s+/g, " ")}</span>
                   </div>
                 )}
-                {collab.commitment && (
-                  <div>
-                    <span className="font-medium text-gray-700">Commitment:</span>
-                    <span className="ml-2 text-gray-600">{collab.commitment}</span>
+                {Array.isArray((item.collaboration as any).projectTypes) && (item.collaboration as any).projectTypes!.length > 0 && (
+                  <div className="flex items-baseline gap-2 flex-wrap">
+                    <span className="font-medium text-gray-700 whitespace-nowrap">Project Types:</span>
+                    <div className="flex flex-wrap gap-2">
+                      {(item.collaboration as any).projectTypes.map((pt: string, i: number) => (
+                        <Badge key={`pt-${i}`} variant="outline" className="capitalize">{formatProjectType(pt as any)}</Badge>
+                      ))}
+                    </div>
                   </div>
                 )}
-                <div>
-                  <span className="font-medium text-gray-700">Type:</span>
-                  <span className="ml-2 text-gray-600 capitalize">{collab.kind}</span>
-                </div>
+                {item.collaboration.stage && (
+                  <div className="flex items-baseline gap-2 overflow-hidden">
+                    <span className="font-medium text-gray-700 whitespace-nowrap">Stage:</span>
+                    <span className="text-gray-600 truncate min-w-0">{formatStage(item.collaboration.stage as any)}</span>
+                  </div>
+                )}
               </div>
             </div>
-
-            <Button>Contact</Button>
+            <div className="flex gap-3 items-center">
+              <CollabUpvoteButton collaborationId={item.collaboration.id} initialCount={item.upvoteCount} hasUserUpvoted={item.hasUserUpvoted} />
+              <HiringToggle collaborationId={item.collaboration.id} isHiring={item.collaboration.isHiring !== false} isOwner={isOwner} />
+            </div>
           </div>
         </div>
 
         {/* Content */}
         <div className="px-6 py-8">
           <div className="mb-8">
-            <h2 className="text-xl font-semibold text-gray-900 mb-4">Description</h2>
-            <div className="text-gray-700 whitespace-pre-wrap leading-relaxed">{collab.description}</div>
+            <h2 className="text-xl font-semibold text-gray-900 mb-4">Project Description</h2>
+            <div className="text-gray-700 whitespace-pre-wrap leading-relaxed">{item.collaboration.description}</div>
           </div>
 
           <div>
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Skills Needed</h3>
-            <div className="flex flex-wrap gap-2">
-              {collab.skills.map((skill, index) => (
-                <Badge key={index} variant="secondary">
-                  {skill}
-                </Badge>
+            <h3 className="text-xl font-semibold text-gray-900 mb-4">Roles Hiring</h3>
+            <div className="space-y-4">
+              {(item.collaboration.lookingFor || []).map((r, index) => (
+                <RoleCard key={index} item={r as any} />
               ))}
+            </div>
+          </div>
+
+          <div className="mt-8 grid grid-cols-1 md:grid-cols-2 gap-6">
+            <div>
+              <h3 className="text-xl font-semibold text-gray-900 mb-2">Contact</h3>
+              <Contact value={item.collaboration.contact} />
+              <div className="mt-4">
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">Tags</h3>
+                <div className="flex flex-wrap gap-2">
+                  {item.tags.technology.map((t) => (
+                    <Badge key={`t-${t.id}`} variant="default" className="text-xs">{t.name}</Badge>
+                  ))}
+                  {item.tags.category.map((t) => (
+                    <Badge key={`c-${t.id}`} variant="outline" className="text-xs">{t.name}</Badge>
+                  ))}
+                </div>
+              </div>
+            </div>
+            {item.collaboration.remarks && (
+              <div>
+                <h3 className="text-xl font-semibold text-gray-900 mb-2">Remarks</h3>
+                <div className="text-gray-700 whitespace-pre-wrap">{item.collaboration.remarks}</div>
+              </div>
+            )}
+          </div>
+
+          <div className="mt-8 p-4 border border-yellow-300 bg-yellow-50 rounded-md text-sm text-yellow-900">
+            Warning: Posts are user-submitted and not verified. Beware of scams/risks, avoid suspicious links, and you are responsible for your actions.
+          </div>
+
+          <div className="mt-8">
+            <h3 className="text-lg font-semibold text-gray-900 mb-4">Comments</h3>
+            <CollabCommentForm collaborationId={item.collaboration.id} />
+            <div className="mt-4">
+              <CollabCommentList comments={item.comments || []} collaborationId={item.collaboration.id} />
             </div>
           </div>
         </div>
@@ -94,3 +146,27 @@ export default async function CollabDetailPage({ params }: CollabDetailPageProps
     </div>
   )
 }
+
+function Contact({ value }: { value: string }) {
+  const v = (value || "").trim()
+  if (!v) return <span className="text-gray-500">Not provided</span>
+  const isUrl = /^https?:\/\//i.test(v)
+  const isEmail = /@/.test(v) && !v.includes(" ")
+  if (isUrl) {
+    return (
+      <a href={v} target="_blank" rel="noopener noreferrer" className="text-blue-600 hover:underline break-all">
+        {v}
+      </a>
+    )
+  }
+  if (isEmail) {
+    return (
+      <a href={`mailto:${v}`} className="text-blue-600 hover:underline break-all">
+        {v}
+      </a>
+    )
+  }
+  return <span className="text-gray-700 break-all">{v}</span>
+}
+
+

--- a/web/app/collaborations/actions.ts
+++ b/web/app/collaborations/actions.ts
@@ -1,0 +1,205 @@
+"use server"
+
+import { redirect } from "next/navigation"
+import { createCollab, updateCollab, deleteCollab, addCollabComment, deleteCollabComment, toggleCollabUpvote } from "@/lib/server/collabs"
+import { createCollabSchema, updateCollabSchema, collabCommentSchema } from "@/app/collaborations/schema"
+import { trackServer } from "@/lib/analytics"
+
+export type CreateCollabState = { fieldErrors?: Record<string, string>; formError?: string } | null
+
+export async function createCollabAction(_: CreateCollabState, formData: FormData): Promise<CreateCollabState> {
+  // Collect tags (multi-value inputs)
+  const techTagIds = formData
+    .getAll("techTagIds")
+    .map((v) => Number(v))
+    .filter((n) => Number.isFinite(n))
+  const categoryTagIds = formData
+    .getAll("categoryTagIds")
+    .map((v) => Number(v))
+    .filter((n) => Number.isFinite(n))
+
+  // Collect "looking for" rows as parallel arrays and zip
+  const roles = formData.getAll("lf_role").map((v) => String(v))
+  const amounts = formData.getAll("lf_amount").map((v) => Number(v))
+  const prereqs = formData.getAll("lf_prerequisite").map((v) => String(v))
+  const goods = formData.getAll("lf_goodToHave").map((v) => String(v))
+  const descs = formData.getAll("lf_description").map((v) => String(v))
+  const maxLen = Math.max(roles.length, amounts.length, prereqs.length, goods.length, descs.length)
+  const lookingFor = Array.from({ length: maxLen }).map((_, i) => ({
+    role: (roles[i] || "").trim(),
+    amount: Number.isFinite(amounts[i]) && amounts[i] > 0 ? Number(amounts[i]) : 1,
+    prerequisite: (prereqs[i] || "").trim(),
+    goodToHave: (goods[i] || "").trim(),
+    description: (descs[i] || "").trim(),
+  }))
+  // Remove empty rows (missing role)
+  const lookingForFiltered = lookingFor.filter((r) => r.role.length > 0)
+
+  const parsed = createCollabSchema.safeParse({
+    title: String(formData.get("title") || ""),
+    affiliatedOrg: String(formData.get("affiliatedOrg") || ""),
+    projectTypes: formData.getAll("projectTypes").map((v) => String(v)),
+    description: String(formData.get("description") || ""),
+    stage: String(formData.get("stage") || ""),
+    lookingFor: lookingForFiltered,
+    contact: String(formData.get("contact") || ""),
+    remarks: String(formData.get("remarks") || ""),
+    techTagIds,
+    categoryTagIds,
+  })
+
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {}
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0] as string
+      if (!fieldErrors[key]) fieldErrors[key] = issue.message
+    }
+    return { fieldErrors }
+  }
+
+  const result = await createCollab(parsed.data)
+  if ("id" in result) {
+    trackServer("collaboration_created", { id: result.id, roles: parsed.data.lookingFor.length })
+    redirect(`/collaborations/${result.id}?created=1`)
+  }
+  return result
+}
+
+export type UpdateCollabState = { fieldErrors?: Record<string, string>; formError?: string; ok?: true } | null
+
+export async function updateCollabAction(_: UpdateCollabState, formData: FormData): Promise<UpdateCollabState> {
+  const id = String(formData.get("id") || "").trim()
+  if (!id) return { formError: "Missing collaboration id" }
+
+  // Same collection strategy as create, but all fields optional
+  const techTagIds = formData
+    .getAll("techTagIds")
+    .map((v) => Number(v))
+    .filter((n) => Number.isFinite(n))
+  const categoryTagIds = formData
+    .getAll("categoryTagIds")
+    .map((v) => Number(v))
+    .filter((n) => Number.isFinite(n))
+
+  const roles = formData.getAll("lf_role").map((v) => String(v))
+  const prereqs = formData.getAll("lf_prerequisite").map((v) => String(v))
+  const goods = formData.getAll("lf_goodToHave").map((v) => String(v))
+  const descs = formData.getAll("lf_description").map((v) => String(v))
+  let lookingFor: Array<{ role: string; prerequisite?: string; goodToHave?: string; description?: string }> | undefined
+  if (roles.length + prereqs.length + goods.length + descs.length > 0) {
+    const maxLen = Math.max(roles.length, prereqs.length, goods.length, descs.length)
+    lookingFor = Array.from({ length: maxLen })
+      .map((_, i) => ({
+        role: (roles[i] || "").trim(),
+        prerequisite: (prereqs[i] || "").trim(),
+        goodToHave: (goods[i] || "").trim(),
+        description: (descs[i] || "").trim(),
+      }))
+      .filter((r) => r.role.length > 0)
+  }
+
+  const candidate = {
+    title: String(formData.get("title") || undefined),
+    affiliatedOrg: String(formData.get("affiliatedOrg") || undefined),
+    kind: (formData.get("kind") ? String(formData.get("kind")) : undefined) as any,
+    projectType: (formData.get("projectType") ? String(formData.get("projectType")) : undefined) as any,
+    description: String(formData.get("description") || undefined),
+    stage: (formData.get("stage") ? String(formData.get("stage")) : undefined) as any,
+    lookingFor,
+    contact: String(formData.get("contact") || undefined),
+    remarks: String(formData.get("remarks") || undefined),
+    // Note: tags update handled separately in UI flow (could be added later)
+  }
+
+  // Optional isHiring toggle
+  const isHiringRaw = formData.get("isHiring")
+  if (typeof isHiringRaw === "string") (candidate as any).isHiring = isHiringRaw === "true"
+
+  const parsed = updateCollabSchema.safeParse(candidate)
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {}
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0] as string
+      if (!fieldErrors[key]) fieldErrors[key] = issue.message
+    }
+    return { fieldErrors }
+  }
+
+  const result = await updateCollab(id, parsed.data)
+  if ("ok" in result) {
+    trackServer("collaboration_updated", { id })
+    return { ok: true }
+  }
+  return result
+}
+
+export type DeleteCollabState = { formError?: string; ok?: true } | null
+
+export async function deleteCollabAction(_: DeleteCollabState, formData: FormData): Promise<DeleteCollabState> {
+  const id = String(formData.get("id") || "").trim()
+  if (!id) return { formError: "Missing collaboration id" }
+  const result = await deleteCollab(id)
+  if ("ok" in result) {
+    trackServer("collaboration_deleted", { id })
+    redirect("/collaborations")
+  }
+  return result
+}
+
+export type ToggleUpvoteState = { formError?: string; ok?: true; upvoted?: boolean; retryAfterSec?: number } | null
+
+export async function toggleCollabUpvoteAction(_: ToggleUpvoteState, formData: FormData): Promise<ToggleUpvoteState> {
+  const collaborationId = String(formData.get("collaborationId") || "").trim()
+  if (!collaborationId) return { formError: "Missing collaboration id" }
+  const result = await toggleCollabUpvote(collaborationId)
+  if ("ok" in result) {
+    trackServer("upvote_toggled", { target: "collaboration", targetId: collaborationId, upvoted: result.upvoted })
+    return { ok: true, upvoted: result.upvoted }
+  }
+  if ((result as any).error === "rate_limited") return { formError: "Too many upvotes. Please slow down.", retryAfterSec: (result as any).retryAfterSec }
+  trackServer("upvote_toggled", { target: "collaboration", targetId: collaborationId, error: (result as any).error })
+  return { formError: (result as any).error || "failed_to_toggle_upvote" }
+}
+
+export type AddCollabCommentState = { fieldErrors?: Record<string, string>; formError?: string; ok?: true; retryAfterSec?: number } | null
+
+export async function addCollabCommentAction(_: AddCollabCommentState, formData: FormData): Promise<AddCollabCommentState> {
+  const collaborationId = String(formData.get("collaborationId") || "").trim()
+  const body = String(formData.get("body") || "")
+  const parentCommentId = String(formData.get("parentCommentId") || "").trim()
+  const fieldErrors: Record<string, string> = {}
+  if (!collaborationId) fieldErrors.collaborationId = "Missing collaboration id"
+
+  const parsed = collabCommentSchema.safeParse({ body })
+  if (!parsed.success) {
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0] as string
+      if (!fieldErrors[key]) fieldErrors[key] = issue.message
+    }
+    return { fieldErrors }
+  }
+
+  const result = await addCollabComment(collaborationId, parsed.data.body, parentCommentId || undefined)
+  if ("id" in result) {
+    trackServer("collab_comment_added", { ok: true, collaborationId })
+    return { ok: true }
+  }
+  if ((result as any).error === "rate_limited") return { formError: "You’re commenting too fast. Please wait a bit.", retryAfterSec: (result as any).retryAfterSec }
+  trackServer("collab_comment_added", { ok: false, collaborationId, error: (result as any).error })
+  return { formError: (result as any).error || "failed_to_add_comment" }
+}
+
+export type DeleteCollabCommentState = { formError?: string; ok?: true } | null
+
+export async function deleteCollabCommentAction(_: DeleteCollabCommentState, formData: FormData): Promise<DeleteCollabCommentState> {
+  const commentId = String(formData.get("commentId") || "").trim()
+  if (!commentId) return { formError: "Missing comment id" }
+  const result = await deleteCollabComment(commentId)
+  if ("ok" in result) {
+    trackServer("collab_comment_deleted", { ok: true, commentId })
+    return { ok: true }
+  }
+  return { formError: (result as any).error || "failed_to_delete_comment" }
+}
+
+

--- a/web/app/collaborations/new/page.tsx
+++ b/web/app/collaborations/new/page.tsx
@@ -1,35 +1,69 @@
 "use client"
 
 import type React from "react"
-import { useState } from "react"
+import { useEffect, useMemo, useState } from "react"
 import { useRouter } from "next/navigation"
+import { useActionState } from "react"
+import { useFormStatus } from "react-dom"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
 import { Select } from "@/components/ui/select"
-import { createCollab } from "@/lib/api/mockCollabs"
-import { useAuth } from "@/lib/api/auth"
-import { useAnalyticsMock } from "@/lib/analytics"
-import { showToast } from "@/components/ui/toast"
+import { useAuth, ensureServerSession } from "@/lib/api/auth"
+import { useTags } from "@/hooks/useTags"
+import { createCollabAction, type CreateCollabState } from "@/app/collaborations/actions"
+import { COLLAB_KIND_OPTIONS, PROJECT_TYPE_OPTIONS, STAGE_OPTIONS } from "@/lib/collabs/options"
 
 export default function NewCollaborationPage() {
   const router = useRouter()
   const { isAuthenticated } = useAuth()
-  const { track } = useAnalyticsMock()
+  const { technology, category } = useTags()
+
+  const [state, formAction] = useActionState<CreateCollabState, FormData>(createCollabAction, null)
 
   const [formData, setFormData] = useState({
     title: "",
+    affiliatedOrg: "",
+    kind: COLLAB_KIND_OPTIONS[0].value as (typeof COLLAB_KIND_OPTIONS)[number]["value"],
+    projectTypes: [PROJECT_TYPE_OPTIONS[0].value] as (typeof PROJECT_TYPE_OPTIONS)[number]["value"][],
     description: "",
-    kind: "ongoing" as "ongoing" | "planned" | "individual" | "organization",
-    skills: "",
-    region: "",
-    commitment: "",
+    stage: "mvp_development" as (typeof STAGE_OPTIONS)[number]["value"],
+    contact: "",
+    remarks: "",
   })
 
-  const [errors, setErrors] = useState<Record<string, string>>({})
-  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [lookingFor, setLookingFor] = useState<Array<{ role: string; amount?: number; prerequisite: string; goodToHave: string; description: string }>>([
+    { role: "", amount: 1, prerequisite: "", goodToHave: "", description: "" },
+  ])
+  const [selectedTechTags, setSelectedTechTags] = useState<number[]>([])
+  const [selectedCategoryTags, setSelectedCategoryTags] = useState<number[]>([])
 
-  // Redirect if not authenticated
+  const errors = state?.fieldErrors || {}
+
+  useEffect(() => {
+    if (isAuthenticated) {
+      ensureServerSession()
+    }
+  }, [isAuthenticated])
+
+  const canSubmit = useMemo(() => {
+    const title = formData.title.trim()
+    const description = formData.description.trim()
+    const contact = formData.contact.trim()
+    const roles = lookingFor.filter((r) => r.role.trim().length > 0)
+    return (
+      title.length > 0 &&
+      title.length <= 160 &&
+      description.length > 0 &&
+      description.length <= 4000 &&
+      contact.length > 0 &&
+      selectedTechTags.length > 0 &&
+      selectedCategoryTags.length > 0 &&
+      roles.length >= 1 &&
+      roles.length <= 5
+    )
+  }, [formData, selectedTechTags, selectedCategoryTags, lookingFor])
+
   if (!isAuthenticated) {
     return (
       <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-12 text-center">
@@ -40,63 +74,27 @@ export default function NewCollaborationPage() {
     )
   }
 
-  const validateForm = () => {
-    const newErrors: Record<string, string> = {}
-
-    if (!formData.title.trim()) {
-      newErrors.title = "Title is required"
-    }
-
-    if (!formData.description.trim()) {
-      newErrors.description = "Description is required"
-    }
-
-    if (!formData.skills.trim()) {
-      newErrors.skills = "At least one skill is required"
-    }
-
-    setErrors(newErrors)
-    return Object.keys(newErrors).length === 0
+  const SubmitButton = () => {
+    const { pending } = useFormStatus()
+    return (
+      <Button type="submit" disabled={pending || !canSubmit} className="flex-1">
+        {pending ? "Posting..." : "Post Collaboration"}
+      </Button>
+    )
   }
 
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault()
-
-    if (!validateForm()) {
-      return
-    }
-
-    setIsSubmitting(true)
-
-    try {
-      const skillsArray = formData.skills
-        .split(",")
-        .map((skill) => skill.trim())
-        .filter((skill) => skill.length > 0)
-
-      const { id } = await createCollab({
-        title: formData.title.trim(),
-        description: formData.description.trim(),
-        kind: formData.kind,
-        skills: skillsArray,
-        region: formData.region.trim() || undefined,
-        commitment: formData.commitment.trim() || undefined,
-      })
-
-      track("collaboration_created", {
-        collaborationId: id,
-        kind: formData.kind,
-        skillsCount: skillsArray.length,
-      })
-
-      showToast("Collaboration posted successfully!", "success")
-      router.push(`/collaborations/${id}`)
-    } catch (error) {
-      showToast("Failed to post collaboration. Please try again.", "error")
-    } finally {
-      setIsSubmitting(false)
-    }
+  const addRole = () => {
+    if (lookingFor.length >= 5) return
+    setLookingFor((prev) => [...prev, { role: "", amount: 1, prerequisite: "", goodToHave: "", description: "" }])
   }
+  const removeRole = (idx: number) => {
+    setLookingFor((prev) => prev.filter((_, i) => i !== idx))
+  }
+  const updateRole = (idx: number, field: keyof (typeof lookingFor)[number], value: string | number) => {
+    setLookingFor((prev) => prev.map((r, i) => (i === idx ? { ...r, [field]: value } : r)))
+  }
+  const toggleTechTag = (id: number) => setSelectedTechTags((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  const toggleCategoryTag = (id: number) => setSelectedCategoryTags((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
 
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -105,97 +103,245 @@ export default function NewCollaborationPage() {
         <p className="text-gray-600 mt-2">Find collaborators for your next project</p>
       </div>
 
-      <form onSubmit={handleSubmit} className="space-y-6">
+      <form action={formAction} className="space-y-6">
         <div>
           <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
             Title *
           </label>
           <Input
             id="title"
+            name="title"
             value={formData.title}
-            onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
+            onChange={(e) => setFormData((p) => ({ ...p, title: e.target.value }))}
             placeholder="Enter collaboration title"
             error={errors.title}
+            maxLength={160}
           />
+          <p className="text-xs text-gray-500 mt-1">{formData.title.length}/160 characters</p>
+        </div>
+
+        {/* Affiliated Org moved below Stage in the new order; Board Type removed */}
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Project Types *
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {PROJECT_TYPE_OPTIONS.map((o) => {
+              const selected = formData.projectTypes.includes(o.value)
+              return (
+                <button
+                  key={o.value}
+                  type="button"
+                  onClick={() => setFormData((p) => ({ ...p, projectTypes: selected ? p.projectTypes.filter((v) => v !== o.value) : [...p.projectTypes, o.value] }))}
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${selected ? "bg-gray-900 text-white" : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"}`}
+                  aria-pressed={selected}
+                >
+                  {o.label}
+                </button>
+              )
+            })}
+          </div>
         </div>
 
         <div>
-          <label htmlFor="kind" className="block text-sm font-medium text-gray-700 mb-2">
-            Type *
+          <label htmlFor="stage" className="block text-sm font-medium text-gray-700 mb-2">
+            Stage *
           </label>
-          <Select
-            id="kind"
-            value={formData.kind}
-            onChange={(e) => setFormData((prev) => ({ ...prev, kind: e.target.value as any }))}
-          >
-            <option value="ongoing">Ongoing</option>
-            <option value="planned">Planned</option>
-            <option value="individual">Individual</option>
-            <option value="organization">Organization</option>
+          <Select id="stage" name="stage" value={formData.stage} onChange={(e) => setFormData((p) => ({ ...p, stage: e.target.value as any }))}>
+            {STAGE_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>{o.label}</option>
+            ))}
           </Select>
         </div>
 
         <div>
+          <label htmlFor="affiliatedOrg" className="block text-sm font-medium text-gray-700 mb-2">
+            Affiliated Organisation (Optional)
+          </label>
+          <Input
+            id="affiliatedOrg"
+            name="affiliatedOrg"
+            value={formData.affiliatedOrg}
+            onChange={(e) => setFormData((p) => ({ ...p, affiliatedOrg: e.target.value }))}
+            placeholder="e.g. Student Club, Company, University"
+            error={errors.affiliatedOrg}
+          />
+        </div>
+
+        <div>
           <label htmlFor="description" className="block text-sm font-medium text-gray-700 mb-2">
-            Description *
+            Project Description *
           </label>
           <Textarea
             id="description"
+            name="description"
             value={formData.description}
-            onChange={(e) => setFormData((prev) => ({ ...prev, description: e.target.value }))}
-            placeholder="Describe your collaboration opportunity, what you're building, and what kind of help you need"
+            onChange={(e) => setFormData((p) => ({ ...p, description: e.target.value }))}
+            placeholder="Describe your collaboration opportunity, what you're building, and what help you need"
             rows={6}
             error={errors.description}
+            maxLength={4000}
           />
+          <p className="text-xs text-gray-500 mt-1">{formData.description.length}/4000 characters</p>
         </div>
 
         <div>
-          <label htmlFor="skills" className="block text-sm font-medium text-gray-700 mb-2">
-            Skills Needed *
+          <label className="block text-sm font-medium text-gray-700 mb-2">
+            Roles Hiring *
           </label>
-          <Input
-            id="skills"
-            value={formData.skills}
-            onChange={(e) => setFormData((prev) => ({ ...prev, skills: e.target.value }))}
-            placeholder="React, TypeScript, UI/UX Design (comma-separated)"
-            error={errors.skills}
-          />
-          <p className="text-xs text-gray-500 mt-1">Separate multiple skills with commas</p>
+          <div className="space-y-4">
+            {lookingFor.map((row, idx) => (
+              <div key={idx} className="border rounded-md p-4">
+                {/* Header row: Role + Amount */}
+                <div className="grid grid-cols-1 md:grid-cols-4 gap-3 mb-3">
+                  <div className="md:col-span-3">
+                    <Input
+                      id={`lf_role_${idx}`}
+                      name="lf_role"
+                      placeholder="Role (e.g., Frontend Engineer)"
+                      value={row.role}
+                      onChange={(e) => updateRole(idx, "role", e.target.value)}
+                      error={errors.lookingFor}
+                    />
+                  </div>
+                  <Input
+                    id={`lf_amount_${idx}`}
+                    name="lf_amount"
+                    type="number"
+                    min={1}
+                    max={99}
+                    placeholder="Amount"
+                    value={row.amount ?? 1}
+                    onChange={(e) => updateRole(idx, "amount", Number(e.target.value || 1))}
+                  />
+                </div>
+
+                {/* Right-indented details block */}
+                <div className="md:pl-4 md:ml-2 md:border-l md:border-gray-200 grid grid-cols-1 gap-4">
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-xs font-medium text-gray-700">Prerequisite</label>
+                      <span className="text-[10px] text-gray-500">{(row.prerequisite?.length || 0)}/400</span>
+                    </div>
+                    <Textarea
+                      id={`lf_prereq_${idx}`}
+                      name="lf_prerequisite"
+                      value={row.prerequisite}
+                      onChange={(e) => updateRole(idx, "prerequisite", e.target.value)}
+                      placeholder="Skills, experience, location, time zone, etc."
+                      rows={3}
+                      maxLength={400}
+                    />
+                  </div>
+
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-xs font-medium text-gray-700">Good to have</label>
+                      <span className="text-[10px] text-gray-500">{(row.goodToHave?.length || 0)}/400</span>
+                    </div>
+                    <Textarea
+                      id={`lf_good_${idx}`}
+                      name="lf_goodToHave"
+                      value={row.goodToHave}
+                      onChange={(e) => updateRole(idx, "goodToHave", e.target.value)}
+                      placeholder="Nice-to-have skills or experience"
+                      rows={3}
+                      maxLength={400}
+                    />
+                  </div>
+
+                  <div>
+                    <div className="flex items-center justify-between mb-1">
+                      <label className="block text-xs font-medium text-gray-700">Description</label>
+                      <span className="text-[10px] text-gray-500">{(row.description?.length || 0)}/1200</span>
+                    </div>
+                    <Textarea
+                      id={`lf_desc_${idx}`}
+                      name="lf_description"
+                      value={row.description}
+                      onChange={(e) => updateRole(idx, "description", e.target.value)}
+                      placeholder="What this role will do; responsibilities and scope"
+                      rows={6}
+                      maxLength={1200}
+                    />
+                  </div>
+                </div>
+
+                <div className="flex justify-end mt-3">
+                  {lookingFor.length > 1 && (
+                    <Button type="button" variant="outline" onClick={() => removeRole(idx)}>Remove</Button>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+          <div className="pt-2">
+            <Button type="button" variant="secondary" onClick={addRole} disabled={lookingFor.length >= 5}>Add role</Button>
+          </div>
         </div>
 
         <div>
-          <label htmlFor="region" className="block text-sm font-medium text-gray-700 mb-2">
-            Location (Optional)
+          <label htmlFor="contact" className="block text-sm font-medium text-gray-700 mb-2">
+            Contact *
           </label>
-          <Input
-            id="region"
-            value={formData.region}
-            onChange={(e) => setFormData((prev) => ({ ...prev, region: e.target.value }))}
-            placeholder="Remote, San Francisco, New York, etc."
-          />
+          <Input id="contact" name="contact" value={formData.contact} onChange={(e) => setFormData((p) => ({ ...p, contact: e.target.value }))} placeholder="Email, Discord, Telegram, etc." error={errors.contact} />
         </div>
 
         <div>
-          <label htmlFor="commitment" className="block text-sm font-medium text-gray-700 mb-2">
-            Time Commitment (Optional)
+          <label htmlFor="remarks" className="block text-sm font-medium text-gray-700 mb-2">
+            Remarks (Optional)
           </label>
-          <Input
-            id="commitment"
-            value={formData.commitment}
-            onChange={(e) => setFormData((prev) => ({ ...prev, commitment: e.target.value }))}
-            placeholder="Part-time (10-15 hours/week), Full-time, Flexible, etc."
-          />
+          <Input id="remarks" name="remarks" value={formData.remarks} onChange={(e) => setFormData((p) => ({ ...p, remarks: e.target.value }))} placeholder="URL, Time Commitment, Additional Info" />
         </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            Technology Tags * {errors.techTagIds && <span className="text-red-600">({errors.techTagIds})</span>}
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {technology.map((tag) => (
+              <button key={tag.id} type="button" onClick={() => toggleTechTag(tag.id)} className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${selectedTechTags.includes(tag.id) ? "bg-blue-100 text-blue-800 border border-blue-200" : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"}`}>
+                {tag.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-3">
+            Category Tags * {errors.categoryTagIds && <span className="text-red-600">({errors.categoryTagIds})</span>}
+          </label>
+          <div className="flex flex-wrap gap-2">
+            {category.map((tag) => (
+              <button key={tag.id} type="button" onClick={() => toggleCategoryTag(tag.id)} className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${selectedCategoryTags.includes(tag.id) ? "bg-green-100 text-green-800 border border-green-200" : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"}`}>
+                {tag.name}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {formData.projectTypes.map((v) => (
+          <input key={`ptype-${v}`} type="hidden" name="projectTypes" value={v} />
+        ))}
+        {selectedTechTags.map((id) => (
+          <input key={`tech-${id}`} type="hidden" name="techTagIds" value={id} />
+        ))}
+        {selectedCategoryTags.map((id) => (
+          <input key={`cat-${id}`} type="hidden" name="categoryTagIds" value={id} />
+        ))}
 
         <div className="flex gap-4 pt-6">
-          <Button type="submit" disabled={isSubmitting} className="flex-1">
-            {isSubmitting ? "Posting..." : "Post Collaboration"}
-          </Button>
-          <Button type="button" variant="outline" onClick={() => router.back()} disabled={isSubmitting}>
+          <SubmitButton />
+          <Button type="button" variant="outline" onClick={() => router.back()}>
             Cancel
           </Button>
         </div>
       </form>
+
+      {state?.formError && (
+        <p className="text-red-600 text-sm mt-4">{state.formError}</p>
+      )}
     </div>
   )
 }

--- a/web/app/collaborations/page.tsx
+++ b/web/app/collaborations/page.tsx
@@ -1,45 +1,30 @@
-"use client"
-
-import { useState, useEffect } from "react"
 import Link from "next/link"
+import { listCollabs } from "@/lib/server/collabs"
+import { Badge } from "@/components/ui/badge"
+import { formatProjectType } from "@/lib/collabs/options"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Select } from "@/components/ui/select"
-import { Badge } from "@/components/ui/badge"
 import { EmptyState } from "@/components/ui/empty-state"
-import { Skeleton } from "@/components/ui/skeleton"
-import { listCollabs } from "@/lib/api/mockCollabs"
-import type { Collaboration } from "@/lib/types"
 
-export default function CollaborationsPage() {
-  const [collaborations, setCollaborations] = useState<Collaboration[]>([])
-  const [loading, setLoading] = useState(true)
-  const [kindFilter, setKindFilter] = useState("")
-  const [skillsFilter, setSkillsFilter] = useState("")
+interface PageProps {
+  searchParams: Promise<{ kind?: string; skills?: string }>
+}
 
-  const loadCollaborations = async () => {
-    setLoading(true)
-    try {
-      const { items } = await listCollabs({
-        kind: kindFilter || undefined,
-        skills: skillsFilter || undefined,
-      })
-      setCollaborations(items)
-    } catch (error) {
-      console.error("Failed to load collaborations:", error)
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  useEffect(() => {
-    loadCollaborations()
-  }, [kindFilter, skillsFilter])
-
-  const handleClearFilters = () => {
-    setKindFilter("")
-    setSkillsFilter("")
-  }
+export default async function CollaborationsPage({ searchParams }: PageProps) {
+  const sp = await searchParams
+  const kind = sp?.kind || ""
+  const skills = sp?.skills || ""
+  const allowedKinds = new Set([
+    "ongoing",
+    "planned",
+    "individual",
+    "organization",
+  ] as const)
+  const kindFilter = allowedKinds.has(kind as any)
+    ? (kind as "ongoing" | "planned" | "individual" | "organization")
+    : undefined
+  const { items } = await listCollabs({ kind: kindFilter, skills: skills || undefined })
 
   return (
     <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -53,132 +38,80 @@ export default function CollaborationsPage() {
         </Button>
       </div>
 
-      {/* Filters */}
       <div className="bg-white rounded-lg border border-gray-200 p-6 mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <h3 className="text-lg font-semibold text-gray-900">Filters</h3>
-          {(kindFilter || skillsFilter) && (
-            <Button variant="outline" size="sm" onClick={handleClearFilters}>
-              Clear Filters
-            </Button>
-          )}
-        </div>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <label htmlFor="kind" className="block text-sm font-medium text-gray-700 mb-2">
-              Type
-            </label>
-            <Select id="kind" value={kindFilter} onChange={(e) => setKindFilter(e.target.value)}>
-              <option value="">All Types</option>
-              <option value="ongoing">Ongoing</option>
-              <option value="planned">Planned</option>
-              <option value="individual">Individual</option>
-              <option value="organization">Organization</option>
-            </Select>
-          </div>
-
-          <div>
-            <label htmlFor="skills" className="block text-sm font-medium text-gray-700 mb-2">
-              Skills
-            </label>
-            <Input
-              id="skills"
-              type="text"
-              placeholder="Search by skills (e.g., React, Python)"
-              value={skillsFilter}
-              onChange={(e) => setSkillsFilter(e.target.value)}
-            />
-          </div>
-        </div>
-      </div>
-
-      {/* Results */}
-      <div className="mb-6">
-        <p className="text-sm text-gray-600">
-          {loading ? "Loading..." : `${collaborations.length} collaborations found`}
-        </p>
-      </div>
-
-      {loading ? (
-        <div className="space-y-6">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <div key={i} className="bg-white rounded-lg border border-gray-200 p-6">
-              <div className="flex items-start justify-between mb-4">
-                <div className="flex-1">
-                  <Skeleton className="h-6 w-3/4 mb-2" />
-                  <Skeleton className="h-4 w-full mb-2" />
-                  <Skeleton className="h-4 w-1/2" />
-                </div>
-                <Skeleton className="h-6 w-20" />
-              </div>
-              <div className="flex gap-2">
-                <Skeleton className="h-6 w-16" />
-                <Skeleton className="h-6 w-20" />
-                <Skeleton className="h-6 w-18" />
-              </div>
+        <form method="get" className="space-y-4">
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            <div>
+              <label htmlFor="kind" className="block text-sm font-medium text-gray-700 mb-2">Type</label>
+              <Select id="kind" name="kind" defaultValue={kind}>
+                <option value="">All Types</option>
+                <option value="ongoing">Ongoing</option>
+                <option value="planned">Planned</option>
+                <option value="individual">Individual</option>
+                <option value="organization">Organization</option>
+              </Select>
             </div>
-          ))}
-        </div>
-      ) : collaborations.length === 0 ? (
+            <div>
+              <label htmlFor="skills" className="block text-sm font-medium text-gray-700 mb-2">Skills / Roles</label>
+              <Input id="skills" name="skills" type="text" placeholder="e.g., React, Designer" defaultValue={skills} />
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" variant="default">Apply</Button>
+            <Button asChild variant="outline"><Link href="/collaborations">Clear</Link></Button>
+          </div>
+        </form>
+      </div>
+
+      <div className="mb-6">
+        <p className="text-sm text-gray-600">{items.length} collaborations found</p>
+      </div>
+
+      {items.length === 0 ? (
         <EmptyState
           title="No collaborations found"
           description="Be the first to post a collaboration opportunity!"
-          action={
-            <Button asChild>
-              <Link href="/collaborations/new">Post Collaboration</Link>
-            </Button>
-          }
-          icon={
-            <svg className="w-12 h-12" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-              />
-            </svg>
-          }
+          action={<Button asChild><Link href="/collaborations/new">Post Collaboration</Link></Button>}
         />
       ) : (
         <div className="space-y-6">
-          {collaborations.map((collab) => (
-            <div
-              key={collab.id}
-              className="bg-white rounded-lg border border-gray-200 p-6 hover:shadow-md transition-shadow"
-            >
+          {items.map((item) => (
+            <div key={item.collaboration.id} className="bg-white rounded-lg border border-gray-200 p-6 hover:shadow-md transition-shadow">
               <div className="flex items-start justify-between mb-4">
                 <div className="flex-1">
                   <div className="flex items-center gap-3 mb-2">
-                    <Badge variant="outline" className="capitalize">
-                      {collab.kind}
-                    </Badge>
-                    <span className="text-sm text-gray-500">by {collab.owner.displayName}</span>
+                    <span className="text-sm text-gray-500">by {item.owner.displayName}</span>
                   </div>
-
-                  <Link href={`/collaborations/${collab.id}`} className="group">
-                    <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 mb-2">
-                      {collab.title}
-                    </h3>
+                  <Link href={`/collaborations/${item.collaboration.id}`} className="group">
+                    <h3 className="text-lg font-semibold text-gray-900 group-hover:text-blue-600 mb-2">{item.collaboration.title}</h3>
                   </Link>
-
-                  <p className="text-gray-600 mb-3 line-clamp-2">{collab.description}</p>
-
+                  <p className="text-gray-600 mb-3 line-clamp-2">{item.collaboration.description}</p>
                   <div className="flex items-center text-sm text-gray-500 space-x-4">
-                    {collab.region && <span>📍 {collab.region}</span>}
-                    {collab.commitment && <span>⏰ {collab.commitment}</span>}
-                    <span>📅 {collab.createdAt.toLocaleDateString()}</span>
+                    <span>📅 {item.collaboration.createdAt.toLocaleDateString?.() || new Date(item.collaboration.createdAt as any).toLocaleDateString()}</span>
+                    {typeof item.commentCount === "number" && <span>💬 {item.commentCount}</span>}
+                    <span>⬆️ {item.upvoteCount}</span>
                   </div>
                 </div>
               </div>
-
-              <div className="flex flex-wrap gap-2">
-                {collab.skills.map((skill, index) => (
-                  <Badge key={index} variant="secondary">
-                    {skill}
-                  </Badge>
-                ))}
+              <div className="mt-2 flex flex-wrap gap-2 items-center">
+                {Array.isArray((item.collaboration as any).projectTypes) && (
+                  <>
+                    {(item.collaboration as any).projectTypes.map((pt: string, i: number) => (
+                      <Badge key={`pt-${i}`} variant="outline" className="capitalize">{formatProjectType(pt as any)}</Badge>
+                    ))}
+                  </>
+                )}
+                <Badge variant={(item.collaboration as any).isHiring === false ? "outline" : undefined} className={(item.collaboration as any).isHiring === false ? "bg-white text-gray-800 border border-gray-300" : "bg-black text-white border border-black"}>
+                  {(item.collaboration as any).isHiring === false ? "No longer hiring" : "Hiring"}
+                </Badge>
               </div>
+              {item.collaboration.lookingFor?.length > 0 && (
+                <div className="mt-2 flex flex-wrap gap-2">
+                  {item.collaboration.lookingFor.slice(0, 3).map((r, idx) => (
+                    <Badge key={idx} variant="secondary">{r.role}</Badge>
+                  ))}
+                </div>
+              )}
             </div>
           ))}
         </div>

--- a/web/app/collaborations/schema.ts
+++ b/web/app/collaborations/schema.ts
@@ -1,0 +1,121 @@
+import { z } from "zod"
+
+export const lookingForItemSchema = z.object({
+  role: z
+    .string()
+    .trim()
+    .min(1, "Role is required")
+    .max(80, "Role must be 80 characters or less"),
+  amount: z
+    .number()
+    .int("Amount must be a whole number")
+    .min(1, "Amount must be at least 1")
+    .max(99, "Amount must be less than 100")
+    .optional(),
+  prerequisite: z
+    .string()
+    .trim()
+    .max(400, "Prerequisite must be 400 characters or less")
+    .optional()
+    .or(z.literal("")),
+  goodToHave: z
+    .string()
+    .trim()
+    .max(400, "Good to have must be 400 characters or less")
+    .optional()
+    .or(z.literal("")),
+  description: z
+    .string()
+    .trim()
+    .max(1200, "Description must be 1200 characters or less")
+    .optional()
+    .or(z.literal("")),
+})
+
+export const createCollabSchema = z.object({
+  title: z
+    .string()
+    .trim()
+    .min(1, "Title is required")
+    .max(160, "Title must be 160 characters or less"),
+  affiliatedOrg: z
+    .string()
+    .trim()
+    .max(200, "Affiliated Organisation must be 200 characters or less")
+    .optional()
+    .or(z.literal("")),
+  // kind removed from UI; server will default it for back-compat
+  projectTypes: z
+    .array(
+      z.enum([
+        "personal",
+        "open_source",
+        "research",
+        "startup_idea_validation",
+        "startup_registered",
+        "student_organization",
+        "university",
+        "ngo",
+        "corporate",
+        "others",
+      ])
+    )
+    .min(1, "Select at least one project type"),
+  description: z
+    .string()
+    .trim()
+    .min(1, "Description is required")
+    .max(4000, "Description must be 4000 characters or less"),
+  stage: z.enum(
+    [
+      "ideation",
+      "planning",
+      "requirements_analysis",
+      "design",
+      "mvp_development",
+      "testing_validation",
+      "implementation_deployment",
+      "monitoring_maintenance",
+      "evaluation_closure",
+      "scaling",
+      "adding_features",
+    ],
+    { required_error: "Stage is required", invalid_type_error: "Stage is invalid" }
+  ),
+  lookingFor: z.array(lookingForItemSchema).min(1, "Add at least one role").max(5, "At most 5 roles"),
+  contact: z
+    .string()
+    .trim()
+    .min(1, "Contact is required")
+    .max(200, "Contact must be 200 characters or less"),
+  remarks: z
+    .string()
+    .trim()
+    .max(1000, "Remarks must be 1000 characters or less")
+    .optional()
+    .or(z.literal("")),
+  techTagIds: z.array(z.number()).min(1, "At least one technology tag is required"),
+  categoryTagIds: z.array(z.number()).min(1, "At least one category tag is required"),
+})
+
+export type CreateCollabInput = z.infer<typeof createCollabSchema>
+
+export const updateCollabSchema = createCollabSchema.partial().extend({
+  // Optional id hint for internal usage (not from client forms)
+  id: z.string().uuid().optional(),
+  isHiring: z.boolean().optional(),
+})
+
+export type UpdateCollabInput = z.infer<typeof updateCollabSchema>
+
+export const collabCommentSchema = z.object({
+  body: z
+    .string()
+    .trim()
+    .min(1, "Comment cannot be empty")
+    .max(1000, "Comment must be 1000 characters or less"),
+})
+
+export type CreateCollabCommentInput = z.infer<typeof collabCommentSchema>
+
+

--- a/web/app/page.tsx
+++ b/web/app/page.tsx
@@ -4,7 +4,7 @@ import { Button } from "@/components/ui/button"
 import { Badge } from "@/components/ui/badge"
 import { listProjects } from "@/lib/server/projects"
 import { UpvoteButton } from "@/components/features/projects/upvote-button"
-import { listCollabs } from "@/lib/api/mockCollabs"
+import { listCollabs } from "@/lib/server/collabs"
 import { getAllTagsServer } from "@/lib/server/tags"
 import type { Tag } from "@/lib/types"
 
@@ -29,7 +29,18 @@ export default async function HomePage() {
   } catch (_) {
     popularProjects = []
   }
-  const { items: collaborations } = await listCollabs({ limit: 3 })
+  let collaborations: Array<{ id: string; title: string; kind: string; rolesCount: number }> = []
+  try {
+    const { items } = await listCollabs({ limit: 3 })
+    collaborations = items.map((it) => ({
+      id: it.collaboration.id,
+      title: it.collaboration.title,
+      kind: it.collaboration.kind,
+      rolesCount: (it.collaboration.lookingFor || []).length,
+    }))
+  } catch (_) {
+    collaborations = []
+  }
   // Load tags from DB with fallback for errors
   let popularTags: Array<{ id: number; name: string; type: string }> = []
   try {
@@ -153,7 +164,7 @@ export default async function HomePage() {
                     <Badge variant="outline" className="text-xs">
                       {collab.kind}
                     </Badge>
-                    <span className="text-xs text-gray-500">{collab.skills.length} skills</span>
+                    <span className="text-xs text-gray-500">{collab.rolesCount} roles</span>
                   </div>
                 </div>
               ))}

--- a/web/app/projects/new/page.tsx
+++ b/web/app/projects/new/page.tsx
@@ -50,7 +50,7 @@ export default function NewProjectPage() {
     const demoUrl = formData.demoUrl.trim()
 
     return (
-      title.length > 0 && title.length <= 80 &&
+      title.length > 0 && title.length <= 160 &&
       tagline.length > 0 && tagline.length <= 140 &&
       description.length > 0 && description.length <= 4000 &&
       demoUrl.length > 0 && /^https?:\/\//.test(demoUrl) &&
@@ -114,9 +114,9 @@ export default function NewProjectPage() {
             onChange={(e) => setFormData((prev) => ({ ...prev, title: e.target.value }))}
             placeholder="Enter your project title"
             error={errors.title}
-            maxLength={80}
+            maxLength={160}
           />
-          <p className="text-xs text-gray-500 mt-1">{formData.title.length}/80 characters</p>
+          <p className="text-xs text-gray-500 mt-1">{formData.title.length}/160 characters</p>
         </div>
 
         <div>

--- a/web/app/projects/schema.ts
+++ b/web/app/projects/schema.ts
@@ -5,7 +5,7 @@ export const createProjectSchema = z.object({
 		.string()
 		.trim()
 		.min(1, "Title is required")
-		.max(80, "Title must be 80 characters or less"),
+		.max(160, "Title must be 160 characters or less"),
 	tagline: z
 		.string()
 		.trim()

--- a/web/components/features/collaborations/collab-comment-form.tsx
+++ b/web/components/features/collaborations/collab-comment-form.tsx
@@ -1,0 +1,85 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState } from "react"
+import { useRouter } from "next/navigation"
+import { useActionState } from "react"
+import { Textarea } from "@/components/ui/textarea"
+import { Button } from "@/components/ui/button"
+import { useFormStatus } from "react-dom"
+import { addCollabCommentAction, type AddCollabCommentState } from "@/app/collaborations/actions"
+import { showToast } from "@/components/ui/toast"
+
+interface CollabCommentFormProps {
+  collaborationId: string
+  parentCommentId?: string
+  onSuccess?: (body: string) => void
+}
+
+export function CollabCommentForm({ collaborationId, parentCommentId, onSuccess }: CollabCommentFormProps) {
+  const router = useRouter()
+  const [body, setBody] = useState("")
+  const [state, formAction] = useActionState<AddCollabCommentState, FormData>(addCollabCommentAction, null)
+  const lastSubmittedBodyRef = useRef("")
+  const processedRef = useRef<AddCollabCommentState>(null)
+
+  const remaining = useMemo(() => 1000 - body.trim().length, [body])
+
+  useEffect(() => {
+    if (!state || processedRef.current === state) return
+    if (state.ok) {
+      showToast("Comment added", "success")
+      setBody("")
+      onSuccess?.(lastSubmittedBodyRef.current)
+      router.refresh()
+    } else if (state.formError) {
+      const suffix = state.retryAfterSec ? ` Try again in ~${state.retryAfterSec}s.` : ""
+      showToast(state.formError + suffix, "error")
+    }
+    processedRef.current = state
+  }, [state])
+
+  const Submit = () => {
+    const { pending } = useFormStatus()
+    return (
+      <Button type="submit" disabled={pending || body.trim().length === 0 || body.trim().length > 1000}>
+        {pending ? "Posting..." : "Post Comment"}
+      </Button>
+    )
+  }
+
+  return (
+    <form
+      action={async (fd: FormData) => {
+        fd.set("collaborationId", collaborationId)
+        if (parentCommentId) fd.set("parentCommentId", parentCommentId)
+        const content = String(fd.get("body") || body)
+        lastSubmittedBodyRef.current = content
+        await formAction(fd)
+      }}
+      className="space-y-3 text-left"
+    >
+      <input type="hidden" name="collaborationId" value={collaborationId} />
+      {parentCommentId && <input type="hidden" name="parentCommentId" value={parentCommentId} />}
+      <div>
+        <Textarea
+          name="body"
+          value={body}
+          onChange={(e) => setBody(e.target.value)}
+          placeholder="Share your thoughts..."
+          rows={4}
+          maxLength={1000}
+          error={state?.fieldErrors?.body}
+        />
+        <div className="flex items-center justify-between mt-1 text-xs text-gray-500">
+          <span>{state?.fieldErrors?.body}</span>
+          <span>{remaining} left</span>
+        </div>
+      </div>
+      <div className="flex justify-end">
+        <Submit />
+      </div>
+    </form>
+  )
+}
+
+

--- a/web/components/features/collaborations/collab-comment-list.tsx
+++ b/web/components/features/collaborations/collab-comment-list.tsx
@@ -1,0 +1,127 @@
+"use client"
+
+import { useEffect, useMemo, useOptimistic, useState } from "react"
+import type { Comment } from "@/lib/types"
+import { Button } from "@/components/ui/button"
+import { deleteCollabCommentAction, type DeleteCollabCommentState } from "@/app/collaborations/actions"
+import { useActionState } from "react"
+import { showToast } from "@/components/ui/toast"
+import { useAuth } from "@/lib/api/auth"
+import { useRouter } from "next/navigation"
+import { CollabCommentForm } from "./collab-comment-form"
+
+interface CollabCommentListProps {
+  comments: Comment[]
+  collaborationId: string
+}
+
+export function CollabCommentList({ comments, collaborationId }: CollabCommentListProps) {
+  const router = useRouter()
+  const { user } = useAuth()
+  const [state, formAction] = useActionState<DeleteCollabCommentState, FormData>(deleteCollabCommentAction, null)
+  const [items, setItems] = useState<Comment[]>(comments || [])
+  const [optimisticItems, setOptimisticItems] = useOptimistic<Comment[], { type: "delete"; id: string }>(
+    items,
+    (current, action) => {
+      if (action.type === "delete") return current.filter((x) => x.id !== action.id)
+      return current
+    }
+  )
+
+  useEffect(() => {
+    setItems(comments || [])
+  }, [comments])
+
+  useEffect(() => {
+    if (state?.formError) {
+      showToast(state.formError, "error")
+    } else if (state?.ok) {
+      showToast("Comment deleted", "success")
+      router.refresh()
+    }
+  }, [state, router])
+
+  if (!optimisticItems || optimisticItems.length === 0) {
+    return <p className="text-gray-500">No comments yet. Be the first to share your thoughts.</p>
+  }
+
+  return (
+    <ul className="space-y-4">
+      {optimisticItems.map((c) => (
+        <li key={c.id} className="border border-gray-200 rounded-md p-4">
+          <div className="flex items-center justify-between mb-2">
+            <div className="text-sm text-gray-600">
+              <span className="font-medium text-gray-900">{c.author.displayName}</span>
+              <span className="mx-2">•</span>
+              <Timestamp value={c.createdAt as unknown as Date | string} />
+            </div>
+            {user?.userId === c.authorId && (
+              <form
+                action={(fd: FormData) => {
+                  const id = String(fd.get("commentId") || "")
+                  setOptimisticItems({ type: "delete", id })
+                  setItems((prev) => prev.filter((x) => x.id !== id))
+                  formAction(fd)
+                }}
+              >
+                <input type="hidden" name="commentId" value={c.id} />
+                <Button type="submit" variant="outline" size="sm">Delete</Button>
+              </form>
+            )}
+          </div>
+          <div className="text-gray-800 whitespace-pre-wrap">{c.body}</div>
+
+          {/* Replies */}
+          {c.children && c.children.length > 0 && (
+            <ul className="mt-3 space-y-3 pl-4 border-l border-gray-200">
+              {c.children.map((r) => (
+                <li key={r.id} className="rounded-md p-3 bg-gray-50">
+                  <div className="text-xs text-gray-600 mb-1">
+                    <span className="font-medium text-gray-900">{r.author.displayName}</span>
+                    <span className="mx-2">•</span>
+                    <Timestamp value={r.createdAt as unknown as Date | string} />
+                  </div>
+                  <div className="text-gray-800 whitespace-pre-wrap text-sm">{r.body}</div>
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Inline reply form */}
+          <div className="mt-3 pl-4">
+            <CollabCommentForm
+              collaborationId={collaborationId}
+              parentCommentId={c.id}
+              onSuccess={(newBody) => {
+                setItems((prev) => prev.map((pc) => {
+                  if (pc.id !== c.id) return pc
+                  const clone = { ...pc }
+                  const reply: Comment = {
+                    id: `temp-${Date.now()}`,
+                    projectId: "",
+                    authorId: user?.userId || "",
+                    author: user || { userId: "", displayName: "You" },
+                    body: newBody,
+                    createdAt: new Date(),
+                    parentCommentId: c.id,
+                  }
+                  clone.children = [...(clone.children || []), reply]
+                  return clone
+                }))
+              }}
+            />
+          </div>
+        </li>
+      ))}
+    </ul>
+  )
+}
+
+function Timestamp({ value }: { value: Date | string }) {
+  const date: Date = typeof value === "string" ? new Date(value) : value
+  const iso = useMemo(() => date.toISOString(), [date])
+  const label = useMemo(() => iso.slice(0, 16).replace("T", " ") + " UTC", [iso])
+  return <time dateTime={iso}>{label}</time>
+}
+
+

--- a/web/components/features/collaborations/collab-upvote-button.tsx
+++ b/web/components/features/collaborations/collab-upvote-button.tsx
@@ -1,0 +1,97 @@
+"use client"
+
+import { useEffect, useMemo, useRef, useState, useTransition } from "react"
+import { useRouter, usePathname } from "next/navigation"
+import { Button } from "@/components/ui/button"
+import { showToast } from "@/components/ui/toast"
+import { useAuth } from "@/lib/api/auth"
+import { useActionState } from "react"
+import { toggleCollabUpvoteAction, type ToggleUpvoteState } from "@/app/collaborations/actions"
+
+interface CollabUpvoteButtonProps {
+  collaborationId: string
+  initialCount: number
+  hasUserUpvoted?: boolean
+  interactive?: boolean
+}
+
+export function CollabUpvoteButton({ collaborationId, initialCount, hasUserUpvoted, interactive = true }: CollabUpvoteButtonProps) {
+  const { isAuthenticated } = useAuth()
+  const router = useRouter()
+  const pathname = usePathname() || "/"
+  const [state, formAction] = useActionState<ToggleUpvoteState, FormData>(toggleCollabUpvoteAction, null)
+  const [isPending, startTransition] = useTransition()
+  const [count, setCount] = useState(initialCount)
+  const [didUpvote, setDidUpvote] = useState(!!hasUserUpvoted)
+  const [lastError, setLastError] = useState<string | null>(null)
+  const clickLockRef = useRef(false)
+
+  // Base count is the total without the current user's vote
+  const baseCount = useMemo(() => {
+    const base = initialCount - (hasUserUpvoted ? 1 : 0)
+    return base < 0 ? 0 : base
+  }, [initialCount, hasUserUpvoted])
+
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault()
+    if (!interactive) return
+    if (!isAuthenticated) {
+      router.push(`/auth/sign-in?redirectTo=${encodeURIComponent(pathname)}`)
+      return
+    }
+    if (isPending || clickLockRef.current) return
+    clickLockRef.current = true
+    const nextUpvoted = !didUpvote
+    // Optimistic count based on baseCount
+    setCount(baseCount + (nextUpvoted ? 1 : 0))
+    setDidUpvote(nextUpvoted)
+    const fd = new FormData()
+    fd.set("collaborationId", collaborationId)
+    startTransition(() => formAction(fd))
+  }
+
+  useEffect(() => {
+    if (state?.formError) {
+      setDidUpvote(!!hasUserUpvoted)
+      setCount(baseCount + (hasUserUpvoted ? 1 : 0))
+      const suffix = state.retryAfterSec ? ` Try again in ~${state.retryAfterSec}s.` : ""
+      setLastError(state.formError + suffix)
+      showToast(state.formError + suffix, "error")
+    } else if (state?.ok && typeof state.upvoted !== "undefined") {
+      setDidUpvote(state.upvoted)
+      setCount(baseCount + (state.upvoted ? 1 : 0))
+      setLastError(null)
+    }
+    if (state) clickLockRef.current = false
+  }, [state, hasUserUpvoted, baseCount])
+
+  if (!interactive) {
+    return (
+      <Button variant={didUpvote ? "default" : "outline"} size="sm" className="flex flex-col items-center min-w-[60px] h-auto py-2" disabled aria-label={`Upvotes: ${count}`}>
+        <svg className="w-4 h-4 mb-1" fill="currentColor" viewBox="0 0 20 20">
+          <path fillRule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clipRule="evenodd" />
+        </svg>
+        <span className="text-xs">{count}</span>
+      </Button>
+    )
+  }
+
+  return (
+    <Button
+      variant={didUpvote ? "default" : "outline"}
+      size="sm"
+      onClick={handleClick}
+      disabled={isPending}
+      className="flex flex-col items-center min-w-[60px] h-auto py-2"
+      title={lastError || undefined}
+      type="button"
+    >
+      <svg className="w-4 h-4 mb-1" fill="currentColor" viewBox="0 0 20 20">
+        <path fillRule="evenodd" d="M3.293 9.707a1 1 0 010-1.414l6-6a1 1 0 011.414 0l6 6a1 1 0 01-1.414 1.414L11 5.414V17a1 1 0 11-2 0V5.414L4.707 9.707a1 1 0 01-1.414 0z" clipRule="evenodd" />
+      </svg>
+      <span className="text-xs">{count}</span>
+    </Button>
+  )
+}
+
+

--- a/web/components/features/collaborations/hiring-toggle.tsx
+++ b/web/components/features/collaborations/hiring-toggle.tsx
@@ -1,0 +1,78 @@
+"use client"
+
+import { useActionState, useEffect, useRef, useState, startTransition } from "react"
+import { Button } from "@/components/ui/button"
+import { Badge } from "@/components/ui/badge"
+import { updateCollabAction, type UpdateCollabState } from "@/app/collaborations/actions"
+import { showToast } from "@/components/ui/toast"
+
+type Props = { collaborationId: string; isHiring: boolean; isOwner: boolean }
+
+export function HiringToggle({ collaborationId, isHiring, isOwner }: Props) {
+  const [state, formAction] = useActionState<UpdateCollabState, FormData>(updateCollabAction, null)
+  const [localHiring, setLocalHiring] = useState<boolean>(isHiring)
+  const pendingRef = useRef(false)
+  const prevHiringRef = useRef<boolean>(isHiring)
+
+  useEffect(() => {
+    // Keep local state in sync if parent prop changes (e.g., server refresh)
+    setLocalHiring(isHiring)
+    prevHiringRef.current = isHiring
+  }, [isHiring])
+
+  useEffect(() => {
+    if (!pendingRef.current || !state) return
+    if (state.ok) {
+      // success, lock in the optimistic state
+      pendingRef.current = false
+      prevHiringRef.current = localHiring
+      return
+    }
+    if (state.formError) {
+      // revert optimistic state on error
+      setLocalHiring(prevHiringRef.current)
+      pendingRef.current = false
+      showToast(`Failed to update hiring status: ${state.formError}`, "error")
+    }
+  }, [state, localHiring])
+
+  const submit = () => {
+    if (pendingRef.current) return
+    pendingRef.current = true
+    const next = !localHiring
+    setLocalHiring(next) // optimistic
+    const fd = new FormData()
+    fd.set("id", collaborationId)
+    fd.set("isHiring", String(next))
+    startTransition(() => {
+      formAction(fd)
+    })
+  }
+
+  const hiringStyles = "bg-black text-white border border-black"
+  const notHiringStyles = "bg-white text-gray-800 border border-gray-300"
+
+  if (!isOwner) {
+    // Read-only indicator for non-owners
+    return (
+      <Badge className={`${localHiring ? hiringStyles : notHiringStyles}`} variant={localHiring ? undefined : "outline"}>
+        {localHiring ? "Hiring" : "No longer hiring"}
+      </Badge>
+    )
+  }
+
+  return (
+    <Button
+      type="button"
+      size="sm"
+      aria-pressed={localHiring}
+      onClick={submit}
+      disabled={pendingRef.current}
+      className={`${localHiring ? hiringStyles : notHiringStyles}`}
+    >
+      {localHiring ? "Hiring" : "No longer hiring"}
+    </Button>
+  )
+}
+
+

--- a/web/components/features/collaborations/role-card.tsx
+++ b/web/components/features/collaborations/role-card.tsx
@@ -1,0 +1,70 @@
+"use client"
+
+import { useMemo, useState } from "react"
+
+type RoleItem = {
+  role: string
+  amount?: number
+  prerequisite?: string
+  goodToHave?: string
+  description?: string
+}
+
+export function RoleCard({ item }: { item: RoleItem }) {
+  const [expanded, setExpanded] = useState(false)
+  const showToggle = useMemo(() => {
+    const totalLen = `${item.prerequisite || ""}${item.goodToHave || ""}${item.description || ""}`.length
+    return totalLen > 220
+  }, [item])
+
+  const clampClass = expanded ? "" : "line-clamp-2"
+
+  return (
+    <div className="border border-gray-200 rounded-md p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-3">
+        <h4 className="text-base md:text-lg font-medium text-gray-900 truncate" title={item.role}>
+          {item.role}
+        </h4>
+        <span
+          className="inline-flex items-center rounded-full bg-gray-100 text-gray-800 px-2.5 py-1 text-xs md:text-sm border border-gray-200"
+          aria-label={`${item.amount ?? 1} ${((item.amount ?? 1) > 1) ? "openings" : "opening"}`}
+        >
+          {(item.amount ?? 1)} {((item.amount ?? 1) > 1) ? "openings" : "opening"}
+        </span>
+      </div>
+
+      {/* Details */}
+      <div className="md:pl-4 md:ml-2 md:border-l md:border-gray-200 grid grid-cols-1 gap-2 text-sm">
+        {item.prerequisite && item.prerequisite.trim().length > 0 && (
+          <div className="flex gap-2">
+            <span className="font-medium text-gray-700">Prerequisite:</span>
+            <span className={`text-gray-700 whitespace-pre-wrap break-words ${clampClass}`}>{item.prerequisite}</span>
+          </div>
+        )}
+        {item.goodToHave && item.goodToHave.trim().length > 0 && (
+          <div className="flex gap-2">
+            <span className="font-medium text-gray-700">Good to have:</span>
+            <span className={`text-gray-700 whitespace-pre-wrap break-words ${clampClass}`}>{item.goodToHave}</span>
+          </div>
+        )}
+        {item.description && item.description.trim().length > 0 && (
+          <div className="flex gap-2">
+            <span className="font-medium text-gray-700">Description:</span>
+            <span className={`text-gray-700 whitespace-pre-wrap break-words ${clampClass}`}>{item.description}</span>
+          </div>
+        )}
+      </div>
+
+      {showToggle && (
+        <div className="mt-2">
+          <button type="button" className="text-xs text-blue-600 hover:underline" onClick={() => setExpanded((v) => !v)}>
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+

--- a/web/lib/analytics.ts
+++ b/web/lib/analytics.ts
@@ -6,6 +6,10 @@ type AnalyticsEvent =
   | "comment_deleted"
   | "reply_added"
   | "collaboration_created"
+  | "collaboration_updated"
+  | "collaboration_deleted"
+  | "collab_comment_added"
+  | "collab_comment_deleted"
   | "collaboration_viewed"
   | "search_performed"
   | "filters_applied"
@@ -17,4 +21,10 @@ export function useAnalyticsMock() {
   }
 
   return { track }
+}
+
+// Server-safe tracker to avoid hook naming in server actions
+export function trackServer(event: AnalyticsEvent, properties?: Record<string, any>) {
+  // TODO: Replace with real analytics service when available
+  console.log(`[Analytics] ${event}`, properties)
 }

--- a/web/lib/collabs/options.ts
+++ b/web/lib/collabs/options.ts
@@ -1,0 +1,89 @@
+export type Option<T extends string> = { value: T; label: string }
+
+// Board segmentation (already readable but included for consistency)
+export const COLLAB_KIND_OPTIONS: Option<"ongoing" | "planned" | "individual" | "organization">[] = [
+  { value: "ongoing", label: "Ongoing" },
+  { value: "planned", label: "Planned" },
+  { value: "individual", label: "Individual" },
+  { value: "organization", label: "Organization" },
+]
+
+// Project type (DB-safe slug values with human labels)
+export const PROJECT_TYPE_OPTIONS: Option<
+  | "personal"
+  | "open_source"
+  | "research"
+  | "startup_idea_validation"
+  | "startup_registered"
+  | "student_organization"
+  | "university"
+  | "ngo"
+  | "corporate"
+  | "others"
+>[] = [
+  { value: "personal", label: "Personal" },
+  { value: "open_source", label: "Open-source" },
+  { value: "research", label: "Research" },
+  { value: "startup_idea_validation", label: "Startup idea validation (not registered)" },
+  { value: "startup_registered", label: "Startup (company registered)" },
+  { value: "student_organization", label: "Student Organization" },
+  { value: "university", label: "University" },
+  { value: "ngo", label: "NGO" },
+  { value: "corporate", label: "Corporate" },
+  { value: "others", label: "Others" },
+]
+
+// Stage (DB-safe slug values with human labels)
+export const STAGE_OPTIONS: Option<
+  | "ideation"
+  | "planning"
+  | "requirements_analysis"
+  | "design"
+  | "mvp_development"
+  | "testing_validation"
+  | "implementation_deployment"
+  | "monitoring_maintenance"
+  | "evaluation_closure"
+  | "scaling"
+  | "adding_features"
+>[] = [
+  { value: "ideation", label: "Ideation" },
+  { value: "planning", label: "Planning" },
+  { value: "requirements_analysis", label: "Requirements Gathering and Analysis" },
+  { value: "design", label: "Design" },
+  { value: "mvp_development", label: "MVP Development" },
+  { value: "testing_validation", label: "Testing and Validation" },
+  { value: "implementation_deployment", label: "Implementation and Deployment" },
+  { value: "monitoring_maintenance", label: "Monitoring and Maintenance" },
+  { value: "evaluation_closure", label: "Evaluation and Closure" },
+  { value: "scaling", label: "Scaling" },
+  { value: "adding_features", label: "Adding new features" },
+]
+
+function toMap<T extends string>(opts: Option<T>[]) {
+  const byValue = new Map<T, string>()
+  const byLabel = new Map<string, T>()
+  for (const o of opts) {
+    byValue.set(o.value, o.label)
+    byLabel.set(o.label, o.value)
+  }
+  return { byValue, byLabel }
+}
+
+export const PROJECT_TYPE_MAP = toMap(PROJECT_TYPE_OPTIONS)
+export const STAGE_MAP = toMap(STAGE_OPTIONS)
+export const COLLAB_KIND_MAP = toMap(COLLAB_KIND_OPTIONS)
+
+export function formatProjectType(value: (typeof PROJECT_TYPE_OPTIONS)[number]["value"]): string {
+  return PROJECT_TYPE_MAP.byValue.get(value) || value
+}
+
+export function formatStage(value: (typeof STAGE_OPTIONS)[number]["value"]): string {
+  return STAGE_MAP.byValue.get(value) || value
+}
+
+export function formatCollabKind(value: (typeof COLLAB_KIND_OPTIONS)[number]["value"]): string {
+  return COLLAB_KIND_MAP.byValue.get(value) || value
+}
+
+

--- a/web/lib/server/collabs.ts
+++ b/web/lib/server/collabs.ts
@@ -1,0 +1,572 @@
+"use server"
+
+import { createClient } from "@supabase/supabase-js"
+import { getServerSupabase } from "@/lib/supabaseServer"
+import type { Profile, Tag } from "@/lib/types"
+import { createCollabSchema, type CreateCollabInput, updateCollabSchema, type UpdateCollabInput, collabCommentSchema } from "@/app/collaborations/schema"
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || ""
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY || ""
+
+function getAnonServerClient() {
+  return createClient(supabaseUrl, supabaseAnonKey)
+}
+
+export interface CollaborationRow {
+  id: string
+  owner_id: string
+  kind: string
+  title: string
+  description: string
+  affiliated_org: string | null
+  project_type: string | null
+  project_types?: string[] | null
+  stage: string | null
+  looking_for: any | null
+  contact: string | null
+  remarks: string | null
+  created_at: string
+  soft_deleted: boolean
+  is_hiring?: boolean
+}
+
+export interface CollaborationWithRelations {
+  collaboration: {
+    id: string
+    ownerId: string
+    kind: "ongoing" | "planned" | "individual" | "organization"
+    title: string
+    description: string
+    affiliatedOrg?: string
+    projectType?: string
+    projectTypes?: string[]
+    stage?: string
+    isHiring?: boolean
+    lookingFor: Array<{ role: string; amount?: number; prerequisite?: string; goodToHave?: string; description?: string }>
+    contact: string
+    remarks?: string
+    createdAt: Date
+  }
+  tags: { technology: Tag[]; category: Tag[] }
+  upvoteCount: number
+  owner: Profile
+  hasUserUpvoted?: boolean
+  commentCount?: number
+  comments?: import("@/lib/types").Comment[]
+}
+
+export async function createCollab(input: CreateCollabInput): Promise<{ id: string } | { fieldErrors?: Record<string, string>; formError?: string }> {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return { formError: "unauthorized" }
+
+  const parsed = createCollabSchema.safeParse(input)
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {}
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0] as string
+      if (!fieldErrors[key]) fieldErrors[key] = issue.message
+    }
+    return { fieldErrors }
+  }
+
+  const {
+    title,
+    affiliatedOrg,
+    // kind removed from UI; keep back-compat default
+    projectTypes,
+    description,
+    stage,
+    lookingFor,
+    contact,
+    remarks,
+    techTagIds,
+    categoryTagIds,
+  } = parsed.data
+
+  const { data: row, error } = await supabase
+    .from("collaborations")
+    .insert({
+      owner_id: auth.user.id,
+      title,
+      kind: "ongoing",
+      description,
+      affiliated_org: affiliatedOrg || null,
+      project_types: (projectTypes as any) || null,
+      stage,
+      looking_for: lookingFor as any,
+      contact,
+      remarks: remarks || null,
+    })
+    .select("id")
+    .single()
+
+  if (error || !row) return { formError: error?.message || "failed_to_create_collab" }
+
+  const collabId: string = row.id
+  const allTagIds = [...new Set([...(techTagIds || []), ...(categoryTagIds || [])])]
+  if (allTagIds.length > 0) {
+    const tagRows = allTagIds.map((tagId) => ({ collaboration_id: collabId, tag_id: tagId }))
+    const { error: tagErr } = await supabase.from("collaboration_tags").insert(tagRows)
+    if (tagErr) {
+      await supabase.from("collaborations").delete().eq("id", collabId)
+      return { formError: tagErr.message }
+    }
+  }
+
+  return { id: collabId }
+}
+
+export interface ListCollabsParams {
+  cursor?: string
+  limit?: number
+  kind?: "ongoing" | "planned" | "individual" | "organization"
+  skills?: string
+  includeClosed?: boolean
+}
+
+export async function listCollabs(params: ListCollabsParams = {}): Promise<{ items: CollaborationWithRelations[]; nextCursor?: string }> {
+  const anon = getAnonServerClient()
+  const limit = params.limit && params.limit > 0 ? params.limit : 20
+
+  async function fetchRows(selectCols: string) {
+    let query = anon.from("collaborations").select(selectCols).eq("soft_deleted", false)
+    if (params.kind) query = query.eq("kind", params.kind)
+    // Placeholder: skills filter to be implemented server-side post-fetch (todo tracked)
+    const { data, error } = await query.order("created_at", { ascending: false }).limit(limit)
+    if (error) throw error
+    return data as any[]
+  }
+
+  let rows: any[] = []
+  try {
+    rows = await fetchRows("id, owner_id, kind, title, description, affiliated_org, project_type, project_types, stage, looking_for, contact, remarks, created_at, soft_deleted, is_hiring")
+  } catch (e: any) {
+    // Fallback for environments where migration hasn't run yet (missing columns)
+    if (e && (e.code === "42703" || /column .* does not exist/i.test(String(e.message || "")))) {
+      rows = await fetchRows("id, owner_id, kind, title, description, created_at, soft_deleted")
+    } else {
+      throw e
+    }
+  }
+  if (!rows || rows.length === 0) return { items: [] }
+
+  // Server-side substring matching over looking_for role/prerequisite/goodToHave/description (case-insensitive)
+  let filtered = rows
+  if (params.skills && params.skills.trim() !== "") {
+    const needle = params.skills.trim().toLowerCase()
+    filtered = rows.filter((r: any) => {
+      const arr: any[] = Array.isArray(r.looking_for) ? r.looking_for : []
+      for (const it of arr) {
+        const role = String((it && it.role) || "").toLowerCase()
+        const pre = String((it && it.prerequisite) || "").toLowerCase()
+        const good = String((it && it.goodToHave) || "").toLowerCase()
+        const desc = String((it && it.description) || "").toLowerCase()
+        if (role.includes(needle) || pre.includes(needle) || good.includes(needle) || desc.includes(needle)) return true
+      }
+      return false
+    })
+  }
+
+  // Default hide closed unless includeClosed is true; tolerate environments without is_hiring column
+  if (!params.includeClosed) {
+    filtered = filtered.filter((r: any) => r.is_hiring !== false)
+  }
+
+  const collabIds = (filtered as any[]).map((r) => r.id as string)
+  const [tagsByCollab, ownersByUser, upvoteCounts] = await Promise.all([
+    fetchTagsByCollabIds(collabIds, anon),
+    fetchOwnersByUserIds((rows as any[]).map((r) => r.owner_id as string), anon),
+    fetchUpvoteCounts(collabIds, anon),
+  ])
+
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  const currentUserId = auth.user?.id || null
+  const userUpvotes = await fetchUserCollabUpvotes(collabIds, currentUserId, anon)
+
+  const items: CollaborationWithRelations[] = (filtered as any[]).map((r) => {
+    return toCollabWithRelations(r as CollaborationRow, tagsByCollab.get(r.id) || { technology: [], category: [] }, ownersByUser.get(r.owner_id), upvoteCounts.get(r.id) || 0, userUpvotes.get(r.id) || false)
+  })
+
+  return { items }
+}
+
+export async function getCollab(id: string): Promise<CollaborationWithRelations | null> {
+  const anon = getAnonServerClient()
+  async function fetchOne(selectCols: string) {
+    const { data, error } = await anon.from("collaborations").select(selectCols).eq("id", id).maybeSingle()
+    if (error) throw error
+    return data as any
+  }
+  let r: any = null
+  try {
+    r = await fetchOne("id, owner_id, kind, title, description, affiliated_org, project_type, project_types, stage, looking_for, contact, remarks, created_at, soft_deleted, is_hiring")
+  } catch (e: any) {
+    if (e && (e.code === "42703" || /column .* does not exist/i.test(String(e.message || "")))) {
+      r = await fetchOne("id, owner_id, kind, title, description, created_at, soft_deleted")
+    } else {
+      throw e
+    }
+  }
+  if (!r || r.soft_deleted) return null
+
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  const currentUserId = auth.user?.id || null
+
+  const [tags, owner, voteCounts, userUpvotes, commentCount, comments] = await Promise.all([
+    fetchTagsByCollabIds([r.id], anon),
+    fetchOwnersByUserIds([r.owner_id], anon),
+    fetchUpvoteCounts([r.id], anon),
+    fetchUserCollabUpvotes([r.id], currentUserId, anon),
+    fetchCommentCount([r.id], anon),
+    fetchCollabComments(r.id, anon, currentUserId),
+  ])
+
+  const result = toCollabWithRelations(r as CollaborationRow, tags.get(r.id) || { technology: [], category: [] }, owner.get(r.owner_id), voteCounts.get(r.id) || 0, userUpvotes.get(r.id) || false, commentCount.get(r.id) || 0)
+  result.comments = comments
+  return result
+}
+
+export async function updateCollab(id: string, fields: UpdateCollabInput): Promise<{ ok: true } | { fieldErrors?: Record<string, string>; formError?: string }> {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return { formError: "unauthorized" }
+
+  const parsed = updateCollabSchema.safeParse(fields)
+  if (!parsed.success) {
+    const fieldErrors: Record<string, string> = {}
+    for (const issue of parsed.error.issues) {
+      const key = issue.path[0] as string
+      if (!fieldErrors[key]) fieldErrors[key] = issue.message
+    }
+    return { fieldErrors }
+  }
+
+  const update: any = {}
+  const allowed = ["title", "affiliatedOrg", "description", "stage", "lookingFor", "contact", "remarks", "isHiring"] as const
+  for (const k of allowed) {
+    if ((parsed.data as any)[k] !== undefined) {
+      const colMap: Record<string, string> = {
+        title: "title",
+        affiliatedOrg: "affiliated_org",
+        description: "description",
+        stage: "stage",
+        lookingFor: "looking_for",
+        contact: "contact",
+        remarks: "remarks",
+        isHiring: "is_hiring",
+      }
+      update[colMap[k as unknown as string]] = (parsed.data as any)[k]
+    }
+  }
+
+  const { error } = await supabase.from("collaborations").update(update).eq("id", id)
+  if (error) return { formError: error.message }
+  return { ok: true }
+}
+
+export async function deleteCollab(id: string): Promise<{ ok: true } | { formError: string }> {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return { formError: "unauthorized" }
+  const { error } = await supabase.from("collaborations").update({ soft_deleted: true }).eq("id", id)
+  if (error) return { formError: error.message }
+  return { ok: true }
+}
+
+export async function toggleCollabUpvote(collaborationId: string): Promise<{ ok: true; upvoted: boolean } | { error: string; retryAfterSec?: number }> {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return { error: "unauthorized" }
+
+  // Simple throttle using existing rate_limits table (same bucket as projects)
+  const rl = await checkRateLimit(supabase, { action: "upvote_toggle", userId: auth.user.id, limit: 10, windowSec: 60 })
+  if (rl.limited) return { error: "rate_limited", retryAfterSec: rl.retryAfterSec }
+
+  const { data: existing, error: checkErr } = await supabase
+    .from("collaboration_upvotes")
+    .select("collaboration_id")
+    .eq("collaboration_id", collaborationId)
+    .eq("user_id", auth.user.id)
+    .maybeSingle()
+  if (checkErr) return { error: checkErr.message }
+
+  if (existing) {
+    const { error: delErr } = await supabase
+      .from("collaboration_upvotes")
+      .delete()
+      .eq("collaboration_id", collaborationId)
+      .eq("user_id", auth.user.id)
+    if (delErr) return { error: delErr.message }
+    return { ok: true, upvoted: false }
+  }
+
+  const { error: insErr } = await supabase
+    .from("collaboration_upvotes")
+    .insert({ collaboration_id: collaborationId, user_id: auth.user.id })
+  if (insErr) return { error: insErr.message }
+  return { ok: true, upvoted: true }
+}
+
+export async function addCollabComment(collaborationId: string, body: string, parentCommentId?: string): Promise<{ id: string } | { error: string; retryAfterSec?: number }> {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return { error: "unauthorized" }
+
+  const parsed = collabCommentSchema.safeParse({ body })
+  if (!parsed.success) {
+    const first = parsed.error.issues[0]
+    return { error: first?.message || "invalid_input" }
+  }
+
+  const rl = await checkRateLimit(supabase, { action: "comment_add", userId: auth.user.id, limit: 5, windowSec: 60 })
+  if (rl.limited) return { error: "rate_limited", retryAfterSec: rl.retryAfterSec }
+
+  // If replying, ensure parent exists and belongs to same collaboration and is top-level
+  if (parentCommentId) {
+    const { data: parent, error: parentErr } = await supabase
+      .from("collab_comments")
+      .select("collaboration_id, parent_comment_id, soft_deleted")
+      .eq("id", parentCommentId)
+      .maybeSingle()
+    if (parentErr) return { error: parentErr.message }
+    if (!parent || parent.soft_deleted) return { error: "not_found" }
+    if (parent.collaboration_id !== collaborationId) return { error: "invalid_parent_collaboration" }
+    if (parent.parent_comment_id) return { error: "invalid_parent_depth" }
+  }
+
+  const { data, error } = await supabase
+    .from("collab_comments")
+    .insert({ collaboration_id: collaborationId, author_id: auth.user.id, body: parsed.data.body, parent_comment_id: parentCommentId || null })
+    .select("id")
+    .single()
+  if (error || !data) return { error: error?.message || "failed_to_add_comment" }
+  return { id: data.id as string }
+}
+
+export async function deleteCollabComment(commentId: string): Promise<{ ok: true } | { error: string }> {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) return { error: "unauthorized" }
+  const { error } = await supabase.from("collab_comments").delete().eq("id", commentId)
+  if (error) return { error: error.message }
+  return { ok: true }
+}
+
+function toCollabWithRelations(
+  row: CollaborationRow,
+  tags: { technology: Tag[]; category: Tag[] },
+  owner: { userId: string; displayName: string } | undefined,
+  upvoteCount: number,
+  hasUserUpvoted: boolean,
+  commentCount?: number
+): CollaborationWithRelations {
+  return {
+    collaboration: {
+      id: row.id,
+      ownerId: row.owner_id,
+      kind: row.kind as any,
+      title: row.title,
+      description: row.description,
+      affiliatedOrg: row.affiliated_org || undefined,
+      projectType: row.project_type || undefined,
+      projectTypes: Array.isArray((row as any).project_types) ? ((row as any).project_types as string[]) : undefined,
+      isHiring: (row as any).is_hiring !== false,
+      stage: row.stage || undefined,
+      lookingFor: Array.isArray(row.looking_for)
+        ? (row.looking_for as any[]).map((it: any) => ({
+            role: String(it?.role || ""),
+            amount: typeof it?.amount === "number" ? it.amount : undefined,
+            prerequisite: it?.prerequisite ? String(it.prerequisite) : undefined,
+            goodToHave: it?.goodToHave ? String(it.goodToHave) : undefined,
+            description: it?.description ? String(it.description) : undefined,
+          }))
+        : [],
+      contact: row.contact || "",
+      remarks: row.remarks || undefined,
+      createdAt: new Date(row.created_at),
+    },
+    tags,
+    upvoteCount,
+    owner: {
+      userId: owner?.userId || row.owner_id,
+      displayName: owner?.displayName || "User",
+    },
+    hasUserUpvoted,
+    commentCount,
+  }
+}
+
+async function fetchTagsByCollabIds(collabIds: string[], anon: ReturnType<typeof getAnonServerClient>) {
+  if (collabIds.length === 0) return new Map<string, { technology: Tag[]; category: Tag[] }>()
+  const { data: rows, error } = await anon
+    .from("collaboration_tags")
+    .select("collaboration_id, tag_id")
+    .in("collaboration_id", collabIds)
+  if (error) throw error
+
+  const tagIds = Array.from(new Set(((rows || []) as any[]).map((r) => r.tag_id as number)))
+  let tagsById = new Map<number, Tag>()
+  if (tagIds.length > 0) {
+    const { data: tags, error: tagErr } = await anon.from("tags").select("id,name,type").in("id", tagIds)
+    if (tagErr) throw tagErr
+    for (const t of (tags || []) as any[]) tagsById.set(t.id as number, { id: t.id, name: t.name, type: t.type })
+  }
+  const map = new Map<string, { technology: Tag[]; category: Tag[] }>()
+  for (const row of (rows || []) as any[]) {
+    const id = row.collaboration_id as string
+    const tag = tagsById.get(row.tag_id as number)
+    if (!tag) continue
+    if (!map.has(id)) map.set(id, { technology: [], category: [] })
+    const bucket = tag.type === "category" ? "category" : "technology"
+    map.get(id)![bucket].push(tag)
+  }
+  return map
+}
+
+async function fetchOwnersByUserIds(userIds: string[], anon: ReturnType<typeof getAnonServerClient>) {
+  if (userIds.length === 0) return new Map<string, { userId: string; displayName: string }>()
+  const { data, error } = await anon
+    .from("profiles")
+    .select("user_id, display_name")
+    .in("user_id", userIds)
+  if (error) throw error
+  const map = new Map<string, { userId: string; displayName: string }>()
+  for (const r of (data || []) as any[]) {
+    map.set(r.user_id as string, { userId: r.user_id, displayName: r.display_name })
+  }
+  return map
+}
+
+async function fetchUpvoteCounts(ids: string[], anon: ReturnType<typeof getAnonServerClient>) {
+  const map = new Map<string, number>()
+  if (ids.length === 0) return map
+  const { data, error } = await anon.from("collaboration_upvotes").select("collaboration_id").in("collaboration_id", ids)
+  if (error) throw error
+  for (const id of ids) map.set(id, 0)
+  for (const r of (data || []) as any[]) {
+    const id = r.collaboration_id as string
+    map.set(id, (map.get(id) || 0) + 1)
+  }
+  return map
+}
+
+async function fetchUserCollabUpvotes(ids: string[], userId: string | null, anon: ReturnType<typeof getAnonServerClient>) {
+  const map = new Map<string, boolean>()
+  if (ids.length === 0 || !userId) return map
+  const { data, error } = await anon
+    .from("collaboration_upvotes")
+    .select("collaboration_id")
+    .in("collaboration_id", ids)
+    .eq("user_id", userId)
+  if (error) throw error
+  for (const r of (data || []) as any[]) {
+    map.set(r.collaboration_id as string, true)
+  }
+  return map
+}
+
+async function fetchCommentCount(ids: string[], anon: ReturnType<typeof getAnonServerClient>) {
+  const map = new Map<string, number>()
+  if (ids.length === 0) return map
+  const { data, error } = await anon
+    .from("collab_comments")
+    .select("collaboration_id")
+    .in("collaboration_id", ids)
+  if (error) throw error
+  for (const id of ids) map.set(id, 0)
+  for (const r of (data || []) as any[]) {
+    map.set(r.collaboration_id as string, (map.get(r.collaboration_id as string) || 0) + 1)
+  }
+  return map
+}
+
+async function fetchCollabComments(collaborationId: string, anon: ReturnType<typeof getAnonServerClient>, currentUserId: string | null) {
+  const { data: topRows, error: topErr } = await anon
+    .from("collab_comments")
+    .select("id, collaboration_id, author_id, body, created_at, soft_deleted")
+    .eq("collaboration_id", collaborationId)
+    .is("parent_comment_id", null)
+    .eq("soft_deleted", false)
+    .order("created_at", { ascending: false })
+  if (topErr) {
+    if (topErr.code === "42P01" || /relation .* does not exist/i.test(String(topErr.message || ""))) return []
+    throw topErr
+  }
+  const parentIds = (topRows || []).map((r: any) => r.id as string)
+  let replyMap = new Map<string, any[]>()
+  if (parentIds.length > 0) {
+    const { data: replyRows, error: repErr } = await anon
+      .from("collab_comments")
+      .select("id, collaboration_id, author_id, body, created_at, soft_deleted, parent_comment_id")
+      .in("parent_comment_id", parentIds)
+      .eq("soft_deleted", false)
+      .order("created_at", { ascending: true })
+    if (repErr) throw repErr
+    for (const r of (replyRows || []) as any[]) {
+      const pid = r.parent_comment_id as string
+      if (!replyMap.has(pid)) replyMap.set(pid, [])
+      replyMap.get(pid)!.push(r)
+    }
+  }
+  const authorIds = Array.from(new Set([...(topRows || []), ...Array.from(replyMap.values()).flat()].map((r: any) => r.author_id as string)))
+  const authors = await fetchOwnersByUserIds(authorIds, anon)
+
+  const toComment = (r: any) => {
+    const profile = authors.get(r.author_id as string)
+    return {
+      id: r.id as string,
+      projectId: "",
+      authorId: r.author_id as string,
+      author: { userId: profile?.userId || (r.author_id as string), displayName: profile?.displayName || "User" },
+      body: r.body as string,
+      createdAt: new Date(r.created_at as string),
+      parentCommentId: (r.parent_comment_id as string) || null,
+    }
+  }
+  const parents = (topRows || []).map(toComment)
+  // attach replies oldest->latest
+  for (const p of parents) {
+    const replies = (replyMap.get(p.id) || []).map(toComment)
+    ;(p as any).children = replies
+  }
+  return parents as any
+}
+
+// Shared rate limit helper (copied from projects.ts to avoid cross-imports)
+async function checkRateLimit(
+  supabase: Awaited<ReturnType<typeof getServerSupabase>>,
+  {
+    action,
+    userId,
+    limit,
+    windowSec,
+  }: { action: string; userId: string; limit: number; windowSec: number }
+): Promise<{ limited: boolean; retryAfterSec?: number }> {
+  const nowMs = Date.now()
+  const windowMs = windowSec * 1000
+  const windowStartMs = Math.floor(nowMs / windowMs) * windowMs
+  const windowStartIso = new Date(windowStartMs).toISOString()
+
+  const { data: existing } = await (supabase as any)
+    .from("rate_limits")
+    .select("count")
+    .eq("action", action)
+    .eq("user_id", userId)
+    .eq("window_start", windowStartIso)
+    .maybeSingle()
+  const current = existing?.count ? Number(existing.count) : 0
+  if (current >= limit) {
+    const retryAfterSec = Math.ceil((windowStartMs + windowMs - nowMs) / 1000)
+    return { limited: true, retryAfterSec }
+  }
+  const nextCount = current + 1
+  await (supabase as any)
+    .from("rate_limits")
+    .upsert({ action, user_id: userId, window_start: windowStartIso, count: nextCount }, { onConflict: "action,user_id,window_start" })
+  return { limited: false }
+}
+
+

--- a/web/tests/collabs.server.test.ts
+++ b/web/tests/collabs.server.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+
+// Helper to build a chainable query mock
+function buildSelectChain(data: any[]) {
+  return {
+    eq: vi.fn().mockReturnThis(),
+    in: vi.fn().mockReturnThis(),
+    is: vi.fn().mockReturnThis(),
+    order: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockResolvedValue({ data, error: null }),
+    maybeSingle: vi.fn().mockResolvedValue({ data: data[0] || null, error: null }),
+  }
+}
+
+// Mock server supabase and supabase-js createClient
+vi.mock("@/lib/supabaseServer", () => ({
+  getServerSupabase: vi.fn(async () => ({
+    auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) },
+    from: vi.fn().mockImplementation((table: string) => ({
+      insert: vi.fn().mockReturnValue({ select: vi.fn().mockReturnValue({ single: vi.fn(async () => ({ data: { id: "c1" } })) }) }),
+      delete: vi.fn().mockReturnValue({ eq: vi.fn(async () => ({}) ) }),
+      update: vi.fn().mockReturnValue({ eq: vi.fn(async () => ({}) ) }),
+      select: vi.fn().mockReturnValue({ single: vi.fn(async () => ({ data: { id: "c1" } })) }),
+    })),
+  }))
+}))
+
+vi.mock("@supabase/supabase-js", () => ({
+  createClient: vi.fn(() => ({
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === "collaborations") {
+        const rows = [
+          { id: "c1", owner_id: "u1", kind: "ongoing", title: "t1", description: "d", looking_for: [{ role: "React Dev" }], created_at: new Date().toISOString(), soft_deleted: false, is_hiring: true },
+          { id: "c2", owner_id: "u1", kind: "planned", title: "t2", description: "d", looking_for: [{ role: "Designer" }], created_at: new Date().toISOString(), soft_deleted: false, is_hiring: true },
+          { id: "c3", owner_id: "u1", kind: "ongoing", title: "t3", description: "d", looking_for: [{ role: "PM" }], created_at: new Date().toISOString(), soft_deleted: false, is_hiring: false },
+        ]
+        const chain = buildSelectChain(rows)
+        return {
+          select: vi.fn(() => chain),
+          // Single fetch path used by getCollab
+          eq: vi.fn().mockReturnThis(),
+          maybeSingle: vi.fn().mockResolvedValue({ data: rows[0], error: null }),
+        }
+      }
+      if (table === "collaboration_tags" || table === "tags" || table === "profiles" || table === "collaboration_upvotes" || table === "collab_comments") {
+        // Return empty sets by default
+        return {
+          select: vi.fn(() => buildSelectChain([])),
+          in: vi.fn(() => buildSelectChain([])),
+        }
+      }
+      return {
+        select: vi.fn(() => buildSelectChain([])),
+      }
+    }),
+  })),
+}))
+
+describe("server collaborations", () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it("createCollab returns id for valid input", async () => {
+    const { createCollab } = await import("@/lib/server/collabs")
+    const res = await createCollab({
+      title: "Title",
+      affiliatedOrg: "",
+      projectTypes: ["personal"],
+      description: "Desc",
+      stage: "ideation",
+      lookingFor: [{ role: "React", amount: 1 }],
+      contact: "me@example.com",
+      remarks: "",
+      techTagIds: [1],
+      categoryTagIds: [2],
+    })
+    expect("id" in (res as any)).toBe(true)
+  })
+
+  it("createCollab rejects when unauthorized", async () => {
+    const { getServerSupabase } = await import("@/lib/supabaseServer")
+    ;(getServerSupabase as any).mockResolvedValueOnce({ auth: { getUser: async () => ({ data: { user: null } }) } })
+    const { createCollab } = await import("@/lib/server/collabs")
+    const res = await createCollab({
+      title: "Title",
+      affiliatedOrg: "",
+      projectTypes: ["personal"],
+      description: "Desc",
+      stage: "ideation",
+      lookingFor: [{ role: "React", amount: 1 }],
+      contact: "me@example.com",
+      remarks: "",
+      techTagIds: [1],
+      categoryTagIds: [2],
+    })
+    expect(res).toEqual({ formError: "unauthorized" })
+  })
+
+  it("listCollabs filters by skills substring (looking_for)", async () => {
+    const { listCollabs } = await import("@/lib/server/collabs")
+    const { items } = await listCollabs({ skills: "react" })
+    expect(items.length).toBe(1)
+    expect(items[0].collaboration.id).toBe("c1")
+  })
+
+  it("listCollabs hides closed (is_hiring=false) by default", async () => {
+    const { listCollabs } = await import("@/lib/server/collabs")
+    const { items } = await listCollabs({})
+    const ids = items.map((i) => i.collaboration.id)
+    expect(ids).not.toContain("c3")
+  })
+
+  it("updateCollab allows toggling isHiring", async () => {
+    const { updateCollab } = await import("@/lib/server/collabs")
+    const res = await updateCollab("c1", { isHiring: false } as any)
+    expect((res as any).ok).toBe(true)
+  })
+})
+
+
+

--- a/web/tests/options.formatting.test.ts
+++ b/web/tests/options.formatting.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest"
+
+describe("collab options formatting", () => {
+  it("formatStage maps value to label", async () => {
+    const { formatStage } = await import("@/lib/collabs/options")
+    expect(formatStage("mvp_development" as any)).toBe("MVP Development")
+    expect(formatStage("requirements_analysis" as any)).toBe("Requirements Gathering and Analysis")
+  })
+
+  it("formatProjectType maps value to label", async () => {
+    const { formatProjectType } = await import("@/lib/collabs/options")
+    expect(formatProjectType("open_source" as any)).toBe("Open-source")
+    expect(formatProjectType("startup_registered" as any)).toBe("Startup (company registered)")
+  })
+})
+
+

--- a/web/tests/projects.schema.test.ts
+++ b/web/tests/projects.schema.test.ts
@@ -35,7 +35,7 @@ describe("createProjectSchema", () => {
 	it("enforces URL and length constraints", async () => {
 		const { createProjectSchema } = await import("@/app/projects/schema")
 		const { success, error } = createProjectSchema.safeParse({
-			title: "x".repeat(81),
+			title: "x".repeat(161),
 			tagline: "y".repeat(141),
 			description: "z".repeat(4001),
 			demoUrl: "ftp://nope",


### PR DESCRIPTION
## Summary
Stage 8 delivers the Collaboration Board MVP:
- New creation form with multi-select project types, default stage, and “Roles Hiring” cards (with amount).
- List and detail pages backed by Supabase (RLS), upvotes, and threaded comments.
- Owner‑only “Hiring/No longer hiring” toggle with optimistic UI; non‑owners see read‑only status.
- Title limit aligned to 160 (projects + collaborations).
- Consistent labels via shared formatters; chips for project types.
- Docs updated across spec, contracts, schema, architecture; added UI patterns doc.
- Tests updated and added; build green.

## Scope of Changes
- UI
  - `/collaborations/new`: Title≤160, Project Types (chips), Stage (default MVP Development), Affiliated Org, Project Description, Roles Hiring (1–5 cards, amount 1–99, counters), Contact, Remarks, Tech/Category Tags.
  - `/collaborations`: filters Kind + skills substring; shows project type chips; hiring status badge; closed posts hidden by default.
  - `/collaborations/[id]`: three‑line info (Affiliated Org → Project Types → Stage), upvote button, threaded comments, warning banner, hiring toggle (owner only).
- Server
  - `web/lib/server/collabs.ts`: `createCollab`, `listCollabs`, `getCollab`, `updateCollab`, `deleteCollab`, `toggleCollabUpvote`, `addCollabComment`, `deleteCollabComment`; skills substring filtering; default `is_hiring=true` in list.
  - `web/app/collaborations/actions.ts`: server actions for the above; analytics hooks (`trackServer`).
- Schema/RLS (reflected in docs; migrations included)
  - collaborations: `affiliated_org`, `project_types text[]`, `is_hiring boolean default true`, `stage`, `looking_for jsonb (role, amount, prerequisite, goodToHave, description)`, `contact`, `remarks`.
  - tables: `collaboration_tags`, `collaboration_upvotes`, `collab_comments (parent_comment_id for 1‑level replies)`.
  - RLS: owner‑only writes; public reads (non‑deleted); upvotes insert/delete by same user; comment author‑only insert/delete; tag joins guarded by ownership.
- Docs
  - `docs/MVP_TECH_SPEC.md`: Stage 8 fully documented and marked ✅.
  - `docs/SERVER_ACTIONS.md`: collaboration contracts (inputs/outputs) and locations.
  - `supabase/schema.md`: table + RLS overview updated.
  - `docs/ARCHITECTURE.md`: Collaborations data flow, server actions, optimistic UI notes.
  - `docs/UI_PATTERNS.md`: optimistic updates, comment ordering, badge conventions, counters, client server‑actions usage.
  - `CHANGELOG.md`: Unreleased entry for Collaboration Board MVP.
- Misc
  - Landing page now uses real `listCollabs` preview.
  - Analytics: added collaboration event types + `trackServer`.

## How to Test
1. Install deps and run tests:
   - `pnpm install --frozen-lockfile`
   - `pnpm test`
2. Build:
   - `pnpm build`
3. App manual:
   - Create: `/collaborations/new` (ensure Title≤160, roles 1–5 with amount, counters work, tags required).
   - List: `/collaborations` (Kind filter, skills substring filter, project type chips, “Hiring” badge; closed posts hidden).
   - Detail: `/collaborations/[id]` (Affiliated Org → Project Types → Stage on three lines; upvote; threaded comments; owner‑only hiring toggle with optimistic update; non‑owner badge).

## Migrations (ensure applied on Supabase)
- `20250825120000_extend_collaborations_add_tags_upvotes_comments.sql`
- `20250825121500_add_collab_comment_replies.sql`
- `20250825123000_collab_project_types_is_hiring.sql`
- After applying, reload PostgREST schema cache if needed:
  - `select pg_notify('pgrst', 'reload schema');`

## Risk & Rollback
- Changes are additive with fallbacks in server code for missing columns; roll back by reverting this branch’s commits.
- RLS additions are scoped to new tables; reverting migrations restores prior behavior.

## Checklist
- [x] Server actions validated (Zod) with clear errors
- [x] RLS enforced (owner writes; public reads where allowed)
- [x] Tests green (unit + integration)
- [x] Docs updated (spec, contracts, schema, architecture, patterns)
- [x] Changelog updated (Unreleased)