### PR TITLE
feat(stage-14): tag curation, per‑facet caps, and new tag picker UX

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+-- Stage 14: Tag curation & validation
+  - Case-insensitive uniqueness for tags at DB: `unique(type, lower(name))`.
+  - Admin tag normalization (trim/collapse whitespace) with friendly duplicate warnings.
+  - Combobox tag picker with quick‑pick chips; per-facet caps (Tech ≤ 5, Category ≤ 3).
+  - Curated initial tag set seeded idempotently; sources cited in `docs/MVP_TECH_SPEC.md` and CSV at `docs/tags/curated-tags.csv`.
 - Global error pages (`web/app/error.tsx`, `web/app/not-found.tsx`) with friendly actions.
 - Error report API (`POST /api/errors/report`) with PII redaction, anonymized user id, rate limiting, and breadcrumbs.
 - Client error reporter (global listeners) with throttling and a 30-cap breadcrumbs ring buffer (routes/clicks).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
--- Stage 14: Tag curation & validation
+- Stage 14: Tag curation & validation
   - Case-insensitive uniqueness for tags at DB: `unique(type, lower(name))`.
   - Admin tag normalization (trim/collapse whitespace) with friendly duplicate warnings.
   - Combobox tag picker with quick‑pick chips; per-facet caps (Tech ≤ 5, Category ≤ 3).
   - Curated initial tag set seeded idempotently; sources cited in `docs/MVP_TECH_SPEC.md` and CSV at `docs/tags/curated-tags.csv`.
+  - Defaults: quick-picks updated (Tech: Agents, LLM, Speech, Vibe Coding, Fine-tuning; Category: Productivity, Education/ Study tools, Content/Media, Research). “Others” is always sorted last in dropdown.
 - Global error pages (`web/app/error.tsx`, `web/app/not-found.tsx`) with friendly actions.
 - Error report API (`POST /api/errors/report`) with PII redaction, anonymized user id, rate limiting, and breadcrumbs.
 - Client error reporter (global listeners) with throttling and a 30-cap breadcrumbs ring buffer (routes/clicks).

--- a/docs/MVP implementation plan/stage 13.md
+++ b/docs/MVP implementation plan/stage 13.md
@@ -1,8 +1,8 @@
 # Stage 13 Implementation Plan: Error Handling, Reporting, and External Link Disclaimer
 
-**Status:** 🚧 Planned  
+**Status:** ✅ Completed 
 **Started:** 16/9/2025  
-**Completed:** —
+**Completed:** 16/9/2025
 
 ## Overview
 
@@ -167,4 +167,4 @@ Always follow this plan, refer back to this document, update the progress after 
 ---
 
 **Last Updated:** 16/9/2025  
-**Next Review:** After Step 2 completion
+**Next Review:** N/A (Stage 13 complete)

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -1,0 +1,270 @@
+# Stage 14 Implementation Plan: Tag Curation & Validation Tweaks
+
+**Status:** In Progress  
+**Started:** 16/9/2025  
+**Completed:** —
+
+## Overview
+
+Stage 14 focuses on improving tag governance and form UX so projects and collaborations stay clear and scannable as the tag vocabulary grows. We will: enforce case‑insensitive uniqueness of tags, cap the number of selected tags in forms, add light tag‑picker refinements (filter, suggested list, scrollable list, selection guardrails), and curate a sensible starting list of technology and category tags. All changes are deliberately minimal and safe, aligning with the existing patterns.
+
+## Tasks
+
+1. Case‑insensitive uniqueness for `tags` at the database level and in Admin UI.
+2. Enforce a cap of 10 total tags (technology + category) for both projects and collaborations (project types do not count toward the collaboration cap).
+3. Light tag‑picker UX refinements in project and collaboration creation forms: filter input, suggested list, scrollable list, selection counter/guardrails.
+4. Curate and seed initial technology/category tags (additive; no renames), and review existing tags.
+5. Tests, documentation updates, and changelog entry.
+6. QA: keep build/test green and verify UX.
+
+## Actionable and Specific Steps
+
+### Step 1: Add case‑insensitive unique index for tags
+**Goal:** Prevent duplicates like "nlp" vs "NLP" by enforcing uniqueness on `type + lower(name)`.
+
+**What we are doing:** Make the database reject adding the same tag with different letter casing, so the tag list stays clean.
+
+**Technical details:**
+- Create a unique index: `create unique index if not exists uq_tags_type_lower_name on tags (type, lower(name));`
+- Keep existing `unique (name, type)` (harmless alongside CI index). Document rationale in schema docs.
+- Add migration; reflect the index in `supabase/schema.sql` and `supabase/schema.md`.
+
+**Files:**
+- Add: `supabase/migrations/20250916000000_add_ci_unique_tags.sql`
+- Change: `supabase/schema.sql`, `supabase/schema.md`
+
+Tests: Apply migration; insert `NLP` then `nlp` → expect unique violation; Admin UI duplicate message shows.
+
+**Status:** Not Started
+
+---
+
+### Step 2: Normalize admin tag input + friendly duplicate messaging
+**Goal:** Ensure whitespace/casing normalized before validation and show a clear error if a case‑insensitive duplicate exists.
+
+**What we are doing:** Clean up the tag name (trim extra spaces) before saving. If the tag already exists (even with different casing), show an easy‑to‑understand error.
+
+**Technical details:**
+- Update validation to trim and collapse inner whitespace (e.g., multiple spaces → single space).
+- Preserve 23505 handling; update error copy to "Tag already exists (case‑insensitive)."
+- Pre‑submit UI check: warn inline if a case‑insensitive match exists.
+
+**Files:**
+- Change: `web/lib/validation/tags.ts` (normalize input)
+- Change: `web/app/admin/tags/actions.ts` (error message)
+- Change: `web/app/admin/tags/tag-manager.tsx` (inline notice before submit)
+- Change: `web/app/admin/tags/AdminCreateTagForm.tsx` (mirror inline notice)
+
+Tests: Unit test normalization; create "  Computer   Vision " → saved as "Computer Vision"; casing duplicate blocked.
+
+**Status:** Not Started
+
+---
+
+### Step 3: Enforce max 10 tags for projects (tech+category)
+**Goal:** Limit total selected tags to at most 10 across technology and category for projects.
+
+**What we are doing:** Prevent picking too many tags so project pages stay readable. Show a counter and stop at 10.
+
+**Technical details:**
+- Server validation: add `.superRefine` to `createProjectSchema` to enforce `techTagIds.length + categoryTagIds.length ≤ 10` with a single clear error message.
+- UI guardrails: show a live counter (e.g., "7/10 selected"); disable additional chips once at 10; allow deselection.
+- No changes to server actions contract beyond error message text.
+
+**Files:**
+- Change: `web/app/projects/schema.ts`
+- Change: `web/app/projects/new/page.tsx`
+- Potentially affected: `web/app/projects/actions.ts` (surface validation errors), `web/tests/projects.schema.test.ts`
+
+Tests: Schema accepts 10 tags, rejects 11; UI disables 11th chip and shows counter.
+
+**Status:** Not Started
+
+---
+
+### Step 4: Enforce max 10 tags for collaborations (tech+category only)
+**Goal:** Limit total selected tags to at most 10 across technology and category for collaborations (project types are not counted).
+
+**What we are doing:** Same cap as projects, but project types (like personal, open source) don't count.
+
+**Technical details:**
+- Server validation: add `.superRefine` to `createCollabSchema` to enforce `techTagIds.length + categoryTagIds.length ≤ 10`.
+- UI guardrails: show a live counter; disable chips once the 10 limit is reached; allow deselection.
+
+**Files:**
+- Change: `web/app/collaborations/schema.ts`
+- Change: `web/app/collaborations/new/page.tsx`
+- Potentially affected: `web/app/collaborations/actions.ts`, new test file `web/tests/collabs.schema.cap.test.ts`
+
+Tests: Schema accepts 10 tags, rejects 11; project types ignored; UI disables 11th tag.
+
+**Status:** Not Started
+
+---
+
+### Step 5: Light tag‑picker UX refinements (both forms)
+**Goal:** Keep forms tidy as the vocabulary grows: add a small search, suggested tags, and scrollable lists with counters.
+
+**What we are doing:** Add a tiny search box to filter tags, show a short "Suggested" list at the top, and make long lists scroll. Also show "X/10 selected" and stop selecting more when full.
+
+**Technical details:**
+- Per facet (Technology, Category):
+  - Filter input that narrows the local chip list (client‑side only).
+  - A curated "Suggested" subsection (first 8–12 curated tags per facet) above the full list.
+  - Wrap full list in a container with `max-height` and `overflow-y: auto`.
+  - Selection counter and chip disabling when at cap.
+- No API/schema changes.
+
+**Files:**
+- Change: `web/app/projects/new/page.tsx`
+- Change: `web/app/collaborations/new/page.tsx`
+
+Tests: Render test verifies filter narrows chips; suggested renders; scroll container present; manual counter/disable works.
+
+**Status:** Not Started
+
+---
+
+### Step 6: Curate and seed initial tag lists; review existing
+**Goal:** Provide a generally understandable set of technology and category tags; review current tags without renaming.
+
+**What we are doing:** Use well‑known sources to draft simple tag lists people understand (e.g., NLP, Computer Vision, Education, Finance). Add them to seeds and check what we already have.
+
+**Technical details:**
+- Research references: Hugging Face Tasks, Papers with Code areas/tasks, Product Hunt Topics.
+- Draft concise lists (e.g., ~12–20 per facet). Submit for review before seeding.
+- Append to `seed_mvp.sql` with `on conflict do nothing` (non‑destructive).
+- Generate a brief report of current tags: case‑insensitive dupes and coverage gaps; include in PR description only (no renames).
+
+**Files:**
+- Change: `supabase/seed/seed_mvp.sql`
+- Add (optional): short report attached in PR description (no repo file changes required)
+
+Tests: Re-run seeds idempotently; curated tags visible in UI; existing tags unchanged; PR report lists dupes/gaps.
+
+**Status:** Not Started
+
+---
+
+### Step 7: Tests
+**Goal:** Ensure validation and basic UX behavior are covered.
+
+**What we are doing:** Add tests so we don’t accidentally break the caps or tag validation later.
+
+**Technical details:**
+- Project cap tests: extend `projects.schema.test.ts` to check pass/fail around 10.
+- Collaboration cap tests: add `collabs.schema.cap.test.ts` (new) for 10‑tag limit excluding project types.
+- Tag validation tests: extend `tags.validation.test.ts` for normalization and case‑insensitive duplicate messaging (unit level).
+
+**Files:**
+- Change: `web/tests/projects.schema.test.ts`
+- Add: `web/tests/collabs.schema.cap.test.ts`
+- Change: `web/tests/tags.validation.test.ts`
+
+Tests: `pnpm test` runs new cases; they pass and fail appropriately when constraints are violated.
+
+**Status:** Not Started
+
+---
+
+### Step 8: Documentation & Changelog
+**Goal:** Keep specs and schema docs accurate; add user‑visible note.
+
+**What we are doing:** Update our manuals so future devs know about the new rules and users see what changed.
+
+**Technical details:**
+- `docs/MVP_TECH_SPEC.md`: mark Stage 14 as done; document 10‑tag cap and CI uniqueness.
+- `supabase/schema.md`: add the new index and rationale.
+- `docs/SERVER_ACTIONS.md`: note validation errors for tag caps.
+- `CHANGELOG.md` under Unreleased: summarize user‑visible changes.
+
+**Files:**
+- Change: `docs/MVP_TECH_SPEC.md`, `supabase/schema.md`, `docs/SERVER_ACTIONS.md`, `CHANGELOG.md`
+
+Tests: Manual doc review; ensure caps and CI uniqueness documented; changelog entry present.
+
+**Status:** In Progress
+
+---
+
+### Step 9: QA (lint/build/tests + manual smoke)
+**Goal:** Ensure everything is green and UX is smooth.
+
+**What we are doing:** Run checks and click through forms to confirm the experience feels right.
+
+**Technical details:**
+- Run `pnpm lint && pnpm test` locally; fix failures.
+- Manual: Admin adds a casing variant → UI warns; DB blocks with friendly error. Project/Collab forms show suggested tags, filter works, lists scroll, and selection caps at 10.
+
+**Files:**
+- No new files; verify changes across touched files.
+Tests: `pnpm lint && pnpm test`; manual Admin duplicate attempt; forms show filter/suggest/scroll and cap at 10.
+
+**Status:** Not Started
+
+---
+
+## Acceptance Criteria
+
+- Database rejects case‑insensitive duplicate tags (`unique(type, lower(name))` in place).
+- Admin tag creation warns for case‑insensitive duplicates and shows a friendly error if submitted.
+- Project and Collaboration forms:
+  - Show a "Suggested" subsection for each facet, plus a scrollable full list.
+  - Provide a filter input per facet that narrows visible tags.
+  - Display a live counter and prevent selecting more than 10 total tags (tech+category). Collaboration cap excludes project types.
+- Curated initial tag lists appended to seeds; existing tags unchanged; brief review report provided in PR.
+- Tests added/updated and passing.
+- Docs updated: MVP spec, schema overview, server actions, and changelog.
+
+## Workflow
+
+At each step in 'Actionable and specific steps':
+
+- Explain clearly on what you are doing and the rationale behind with layman's term, and add detailed explanation if technical term is used.
+- Inspect relevant code, documents, and '.cursorrules' before making change.
+- Code the changes, and make sure codes are robust, reusable and modular.
+- Identidy the files that the code would affect and prevent any bug.
+- Add testcases for the change. Then, make sure all testcases are passed.
+- After each atmoic change, guide user to review it
+- Push changes to Github ONLY when you gain user's review and approval 
+- Do not forget to update progress tracking and other relevant documents.
+- Proceed to the next step in 'Actionable and specific steps'
+
+## Progress Tracking
+
+| Step | Status | Started | Completed | Notes |
+|------|--------|---------|-----------|-------|
+| 1. CI unique index | In Progress | 16/9/2025 | — | Migration + schema docs updated |
+| 2. Admin tag normalization + messaging | In Progress | 16/9/2025 | — | Inline warning + error copy |
+| 3. Project 10‑tag cap | Not Started | — | — | Schema refine + UI counter/disable |
+| 4. Collaboration 10‑tag cap | Not Started | — | — | Exclude project types from cap |
+| 5. Tag‑picker UX (filter/suggest/scroll/counter) | Not Started | — | — | Both forms |
+| 6. Curate & seed + review existing | Not Started | — | — | Append seeds; PR review report |
+| 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
+| 8. Docs & Changelog | Not Started | — | — | Spec, schema, actions, changelog |
+| 9. QA | Not Started | — | — | Lint/test + manual smoke |
+
+## Risk Mitigation
+
+**Data integrity**
+- CI unique index prevents duplicate tags differing by case; keep existing unique (name, type) to avoid accidental removal.
+- Seeds use `on conflict do nothing` to stay idempotent.
+
+**UX regressions**
+- Keep refinements minimal (client‑side filter, small suggested list, scroll, counter) with no API changes.
+- Disable chips above cap while allowing deselection; clear inline messaging.
+
+**Compatibility**
+- No breaking changes to server action contracts; only additional validation error possible for caps.
+- Admin UI changes are additive; existing admin flows continue to work.
+
+**Testing & rollout**
+- Add unit tests for schema refinements and validation.
+- Manual smoke on forms and admin page before merging.
+
+---
+
+**Last Updated:** 16/9/2025  
+**Next Review:** On implementation completion
+
+

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -35,7 +35,7 @@ Stage 14 focuses on improving tag governance and form UX so projects and collabo
 
 Tests: Apply migration; insert `NLP` then `nlp` → expect unique violation; Admin UI duplicate message shows.
 
-**Status:** In Progress
+**Status:** Completed
 
 ---
 
@@ -78,7 +78,7 @@ Tests: Unit test normalization; create "  Computer   Vision " → saved as "Comp
 
 Tests: Schema accepts 10 tags, rejects 11; UI disables 11th chip and shows counter.
 
-**Status:** In Progress
+**Status:** Completed
 
 ---
 
@@ -220,24 +220,26 @@ Tests: `pnpm lint && pnpm test`; manual Admin duplicate attempt; forms show filt
 
 At each step in 'Actionable and specific steps':
 
-- Explain clearly on what you are doing and the rationale behind with layman's term, and add detailed explanation if technical term is used.
-- Inspect relevant code, documents, and '.cursorrules' before making change.
-- Code the changes, and make sure codes are robust, reusable and modular.
+- Explain clearly on what you are doing and the rationale behind with layman's term, and add detailed explanation if technical term is used. 
+- Inspect relevant code, documents, and ‘.cursorrules’ before making change.
+- Code the changes, and make sure codes are robust, reusable and modular. 
 - Identidy the files that the code would affect and prevent any bug.
 - Add testcases for the change. Then, make sure all testcases are passed.
-- After each atmoic change, guide user to review it
-- Push changes to Github ONLY when you gain user's review and approval 
-- Do not forget to update progress tracking and other relevant documents.
-- Proceed to the next step in 'Actionable and specific steps'
+- Guide user to review the code changes and functionality change in UI.
+- After user's review and approval, update progress tracking and other relevant documents.
+- Lastly, commit and push changes to Github.
+- ONLY when everything above is done, proceed to the next step in ‘Actionable and specific steps’
+
+If you need help from user, give clear instructions to user on how to do it or what needs to be decided on.
 
 ## Progress Tracking
 
 | Step | Status | Started | Completed | Notes |
 |------|--------|---------|-----------|-------|
-| 1. CI unique index | In Progress | 16/9/2025 | — | Migration + schema docs updated |
-| 2. Admin tag normalization + messaging | In Progress | 16/9/2025 | — | Inline warning + error copy |
-| 3. Project 10‑tag cap | Not Started | — | — | Schema refine + UI counter/disable |
-| 4. Collaboration 10‑tag cap | Not Started | — | — | Exclude project types from cap |
+| 1. CI unique index | Completed | 16/9/2025 | 17/9/2025 | Migration + schema docs updated |
+| 2. Admin tag normalization + messaging | Completed | 17/9/2025 | — | Inline warning + error copy |
+| 3. Project 10‑tag cap | Completed | 16/9/2025 | 17/9/2025 | Schema superRefine + UI counter/disable |
+| 4. Collaboration 10‑tag cap | Completed | 16/9/2025 | 17/9/2025 | Exclude project types from cap; UI aligned with projects |
 | 5. Tag‑picker UX (filter/suggest/scroll/counter) | Not Started | — | — | Both forms |
 | 6. Curate & seed + review existing | Not Started | — | — | Append seeds; PR review report |
 | 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
@@ -264,7 +266,7 @@ At each step in 'Actionable and specific steps':
 
 ---
 
-**Last Updated:** 16/9/2025  
+**Last Updated:** 17/9/2025
 **Next Review:** On implementation completion
 
 

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -1,6 +1,6 @@
 # Stage 14 Implementation Plan: Tag Curation & Validation Tweaks
 
-**Status:** In Progress  
+**Status:** Completed  
 **Started:** 16/9/2025  
 **Completed:** —
 
@@ -121,7 +121,25 @@ Tests: Schema accepts 10 tags, rejects 11; project types ignored; UI disables 11
 
 Tests: Render test verifies filter narrows chips; suggested renders; scroll container present; manual counter/disable works.
 
-**Status:** Not Started
+**Status:** Completed
+
+### Step 5b: Replace tag lists with combobox + quick‑pick chips
+**Goal:** Reduce visual clutter and align with industry patterns (chips + searchable combobox).
+
+**What we are doing:** Show a short row of quick‑pick chips (curated) and a single combobox to add more by searching alphabetically. Selected chips render inline; non‑selected options are hidden from the list. Cap is enforced per facet.
+
+**Technical details:**
+- New reusable `TagMultiSelect` component with props `{ label, options, value, onChange, max, pinned?, variant }`.
+- Features: quick‑pick chips (toggle), searchable dropdown (substring + alphabetical), keyboardable, click ▾ to toggle, click area to open, blur closes. Variants style colors (tech=blue, category=green).
+- Per‑facet caps: Technology ≤ 5, Category ≤ 3.
+
+**Files:**
+- Add: `web/components/ui/tag-multiselect.tsx`
+- Change: `web/app/projects/new/page.tsx`, `web/app/collaborations/new/page.tsx`
+
+Tests: Component covered indirectly; end‑to‑end caps validated by schema tests; manual UI check for open/close and pin behavior.
+
+**Status:** In Progress
 
 ---
 
@@ -240,7 +258,8 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 2. Admin tag normalization + messaging | Completed | 17/9/2025 | — | Inline warning + error copy |
 | 3. Project 10‑tag cap | Completed | 16/9/2025 | 17/9/2025 | Schema superRefine + UI counter/disable |
 | 4. Collaboration 10‑tag cap | Completed | 16/9/2025 | 17/9/2025 | Exclude project types from cap; UI aligned with projects |
-| 5. Tag‑picker UX (filter/suggest/scroll/counter) | Not Started | — | — | Both forms |
+| 5. Tag‑picker UX (filter/suggest/scroll/counter) | Completed | 17/9/2025 | 17/9/2025 | Replaced with combobox + quick‑picks |
+| 5b. Combobox + quick‑picks | Completed | 17/9/2025 | 17/9/2025 | `TagMultiSelect` integrated |
 | 6. Curate & seed + review existing | Not Started | — | — | Append seeds; PR review report |
 | 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
 | 8. Docs & Changelog | Not Started | — | — | Spec, schema, actions, changelog |

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -2,7 +2,7 @@
 
 **Status:** Completed  
 **Started:** 16/9/2025  
-**Completed:** —
+**Completed:** 18/9/2025
 
 ## Overview
 
@@ -207,7 +207,7 @@ Tests: `pnpm test` runs new cases; they pass and fail appropriately when constra
 
 Tests: Manual doc review; ensure caps and CI uniqueness documented; changelog entry present.
 
-**Status:** In Progress
+**Status:** Completed
 
 ---
 
@@ -224,7 +224,7 @@ Tests: Manual doc review; ensure caps and CI uniqueness documented; changelog en
 - No new files; verify changes across touched files.
 Tests: `pnpm lint && pnpm test`; manual Admin duplicate attempt; forms show filter/suggest/scroll and cap at 10.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -268,8 +268,8 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 6. Curate & seed + review existing | Completed | 17/9/2025 | 18/9/2025 | Curated CSV + seeds applied |
 | 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
 | 7. Tests | Completed | 18/9/2025 | 18/9/2025 | Added util test for 'Others' sorting; suite green |
-| 8. Docs & Changelog | Not Started | — | — | Spec, schema, actions, changelog |
-| 9. QA | Not Started | — | — | Lint/test + manual smoke |
+| 8. Docs & Changelog | Completed | 18/9/2025 | 18/9/2025 | UI patterns + spec aligned; changelog updated |
+| 9. QA | Completed | 18/9/2025 | 18/9/2025 | Tests green; scoped lint on changed files clean |
 
 ## Risk Mitigation
 
@@ -291,7 +291,7 @@ If you need help from user, give clear instructions to user on how to do it or w
 
 ---
 
-**Last Updated:** 17/9/2025
+**Last Updated:** 18/9/2025
 **Next Review:** On implementation completion
 
 

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -35,7 +35,7 @@ Stage 14 focuses on improving tag governance and form UX so projects and collabo
 
 Tests: Apply migration; insert `NLP` then `nlp` → expect unique violation; Admin UI duplicate message shows.
 
-**Status:** Not Started
+**Status:** In Progress
 
 ---
 
@@ -57,7 +57,7 @@ Tests: Apply migration; insert `NLP` then `nlp` → expect unique violation; Adm
 
 Tests: Unit test normalization; create "  Computer   Vision " → saved as "Computer Vision"; casing duplicate blocked.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -78,7 +78,7 @@ Tests: Unit test normalization; create "  Computer   Vision " → saved as "Comp
 
 Tests: Schema accepts 10 tags, rejects 11; UI disables 11th chip and shows counter.
 
-**Status:** Not Started
+**Status:** In Progress
 
 ---
 

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -11,7 +11,7 @@ Stage 14 focuses on improving tag governance and form UX so projects and collabo
 ## Tasks
 
 1. Case‑insensitive uniqueness for `tags` at the database level and in Admin UI.
-2. Enforce a cap of 10 total tags (technology + category) for both projects and collaborations (project types do not count toward the collaboration cap).
+2. Enforce per‑facet caps for both projects and collaborations: Technology ≤ 5 and Category ≤ 3 (project types do not count toward the collaboration cap).
 3. Light tag‑picker UX refinements in project and collaboration creation forms: filter input, suggested list, scrollable list, selection counter/guardrails.
 4. Curate and seed initial technology/category tags (additive; no renames), and review existing tags.
 5. Tests, documentation updates, and changelog entry.
@@ -82,14 +82,14 @@ Tests: Schema accepts 10 tags, rejects 11; UI disables 11th chip and shows count
 
 ---
 
-### Step 4: Enforce max 10 tags for collaborations (tech+category only)
+### Step 4: Enforce per‑facet caps for collaborations (tech + category only)
 **Goal:** Limit total selected tags to at most 10 across technology and category for collaborations (project types are not counted).
 
 **What we are doing:** Same cap as projects, but project types (like personal, open source) don't count.
 
 **Technical details:**
-- Server validation: add `.superRefine` to `createCollabSchema` to enforce `techTagIds.length + categoryTagIds.length ≤ 10`.
-- UI guardrails: show a live counter; disable chips once the 10 limit is reached; allow deselection.
+- Server validation: add `.superRefine` to `createCollabSchema` to enforce per‑facet caps (Technology ≤ 5; Category ≤ 3). Project types are not counted.
+- UI guardrails: show live per‑facet counters; disable chips once the facet cap is reached; allow deselection.
 
 **Files:**
 - Change: `web/app/collaborations/schema.ts`
@@ -98,7 +98,7 @@ Tests: Schema accepts 10 tags, rejects 11; UI disables 11th chip and shows count
 
 Tests: Schema accepts 10 tags, rejects 11; project types ignored; UI disables 11th tag.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -139,7 +139,7 @@ Tests: Render test verifies filter narrows chips; suggested renders; scroll cont
 
 Tests: Component covered indirectly; end‑to‑end caps validated by schema tests; manual UI check for open/close and pin behavior.
 
-**Status:** In Progress
+**Status:** Completed
 
 ---
 
@@ -157,6 +157,8 @@ Tests: Component covered indirectly; end‑to‑end caps validated by schema tes
 - Draft lists (longer allowed due to searchable dropdown). Include: Vibe Coding, Data Science, Data Analytics, Traditional ML, Model Training, Fine‑tuning; plus Sports, Marketing, and common university subjects.
 - Append to `seed_mvp.sql` with `on conflict do nothing` (non‑destructive).
 - Store the curated snapshot at `docs/tags/curated-tags.csv` for provenance.
+
+Note: While the general rule was to avoid renames, we applied a targeted migration to remap the broad `Education` category to the more specific `Education/ Study tools` to improve clarity. See migration `20250918120000_remap_education_to_study_tools.sql`.
 
 **Files:**
 - Change: `supabase/seed/seed_mvp.sql`
@@ -185,7 +187,7 @@ Tests: Re-run seeds idempotently; curated tags visible in UI; existing tags unch
 
 Tests: `pnpm test` runs new cases; they pass and fail appropriately when constraints are violated.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -231,9 +233,8 @@ Tests: `pnpm lint && pnpm test`; manual Admin duplicate attempt; forms show filt
 - Database rejects case‑insensitive duplicate tags (`unique(type, lower(name))` in place).
 - Admin tag creation warns for case‑insensitive duplicates and shows a friendly error if submitted.
 - Project and Collaboration forms:
-  - Show a "Suggested" subsection for each facet, plus a scrollable full list.
-  - Provide a filter input per facet that narrows visible tags.
-  - Display a live counter and prevent selecting more than 10 total tags (tech+category). Collaboration cap excludes project types.
+  - Use a compact combobox with quick‑pick chips; searchable dropdown; scrollable list.
+  - Display live counters per facet and prevent selecting beyond facet caps (Technology ≤ 5; Category ≤ 3). Collaboration cap excludes project types.
 - Curated initial tag lists appended to seeds; existing tags unchanged; brief review report provided in PR.
 - Tests added/updated and passing.
 - Docs updated: MVP spec, schema overview, server actions, and changelog.
@@ -266,6 +267,7 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 5b. Combobox + quick‑picks | Completed | 17/9/2025 | 17/9/2025 | `TagMultiSelect` integrated |
 | 6. Curate & seed + review existing | Completed | 17/9/2025 | 18/9/2025 | Curated CSV + seeds applied |
 | 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
+| 7. Tests | Completed | 18/9/2025 | 18/9/2025 | Added util test for 'Others' sorting; suite green |
 | 8. Docs & Changelog | Not Started | — | — | Spec, schema, actions, changelog |
 | 9. QA | Not Started | — | — | Lint/test + manual smoke |
 

--- a/docs/MVP implementation plan/stage 14.md
+++ b/docs/MVP implementation plan/stage 14.md
@@ -149,10 +149,14 @@ Tests: Component covered indirectly; end‑to‑end caps validated by schema tes
 **What we are doing:** Use well‑known sources to draft simple tag lists people understand (e.g., NLP, Computer Vision, Education, Finance). Add them to seeds and check what we already have.
 
 **Technical details:**
-- Research references: Hugging Face Tasks, Papers with Code areas/tasks, Product Hunt Topics.
-- Draft concise lists (e.g., ~12–20 per facet). Submit for review before seeding.
+- Research references and cite links in spec:
+  - Hugging Face — Tasks (https://huggingface.co/tasks)
+  - Papers with Code — Tasks (https://paperswithcode.com/task)
+  - Product Hunt — Topics (https://www.producthunt.com/topics)
+  - LinkedIn — Industry codes (https://learn.microsoft.com/linkedin/shared/references/reference-tables/industry-codes)
+- Draft lists (longer allowed due to searchable dropdown). Include: Vibe Coding, Data Science, Data Analytics, Traditional ML, Model Training, Fine‑tuning; plus Sports, Marketing, and common university subjects.
 - Append to `seed_mvp.sql` with `on conflict do nothing` (non‑destructive).
-- Generate a brief report of current tags: case‑insensitive dupes and coverage gaps; include in PR description only (no renames).
+- Store the curated snapshot at `docs/tags/curated-tags.csv` for provenance.
 
 **Files:**
 - Change: `supabase/seed/seed_mvp.sql`
@@ -160,7 +164,7 @@ Tests: Component covered indirectly; end‑to‑end caps validated by schema tes
 
 Tests: Re-run seeds idempotently; curated tags visible in UI; existing tags unchanged; PR report lists dupes/gaps.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -260,7 +264,7 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 4. Collaboration 10‑tag cap | Completed | 16/9/2025 | 17/9/2025 | Exclude project types from cap; UI aligned with projects |
 | 5. Tag‑picker UX (filter/suggest/scroll/counter) | Completed | 17/9/2025 | 17/9/2025 | Replaced with combobox + quick‑picks |
 | 5b. Combobox + quick‑picks | Completed | 17/9/2025 | 17/9/2025 | `TagMultiSelect` integrated |
-| 6. Curate & seed + review existing | Not Started | — | — | Append seeds; PR review report |
+| 6. Curate & seed + review existing | Completed | 17/9/2025 | 18/9/2025 | Curated CSV + seeds applied |
 | 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
 | 8. Docs & Changelog | Not Started | — | — | Spec, schema, actions, changelog |
 | 9. QA | Not Started | — | — | Lint/test + manual smoke |

--- a/docs/MVP implementation plan/template.md
+++ b/docs/MVP implementation plan/template.md
@@ -1,0 +1,272 @@
+# Stage X Implementation Plan: Name of Stage X
+
+**Status:** Planned  
+**Started:** Today's date 
+**Completed:** —
+
+## Overview
+
+Overview of stage X
+
+## Tasks
+
+1. Case‑insensitive uniqueness for `tags` at the database level and in Admin UI.
+2. Enforce a cap of 10 total tags (technology + category) for both projects and collaborations (project types do not count toward the collaboration cap).
+3. Light tag‑picker UX refinements in project and collaboration creation forms: filter input, suggested list, scrollable list, selection counter/guardrails.
+4. Curate and seed initial technology/category tags (additive; no renames), and review existing tags.
+5. Tests, documentation updates, and changelog entry.
+6. QA: keep build/test green and verify UX.
+
+## Actionable and Specific Steps
+
+### Step 1: Add case‑insensitive unique index for tags
+**Goal:** Prevent duplicates like "nlp" vs "NLP" by enforcing uniqueness on `type + lower(name)`.
+
+**What we are doing:** Make the database reject adding the same tag with different letter casing, so the tag list stays clean.
+
+**Technical details:**
+- Create a unique index: `create unique index if not exists uq_tags_type_lower_name on tags (type, lower(name));`
+- Keep existing `unique (name, type)` (harmless alongside CI index). Document rationale in schema docs.
+- Add migration; reflect the index in `supabase/schema.sql` and `supabase/schema.md`.
+
+**Files:**
+- Add: `supabase/migrations/20250916_add_ci_unique_tags.sql`
+- Change: `supabase/schema.sql`, `supabase/schema.md`
+
+Tests: Apply migration; insert `NLP` then `nlp` → expect unique violation; Admin UI duplicate message shows.
+
+**Status:** Not Started
+
+---
+
+### Step 2: Normalize admin tag input + friendly duplicate messaging
+**Goal:** Ensure whitespace/casing normalized before validation and show a clear error if a case‑insensitive duplicate exists.
+
+**What we are doing:** Clean up the tag name (trim extra spaces) before saving. If the tag already exists (even with different casing), show an easy‑to‑understand error.
+
+**Technical details:**
+- Update validation to trim and collapse inner whitespace (e.g., multiple spaces → single space).
+- Preserve 23505 handling; update error copy to "Tag already exists (case‑insensitive)."
+- Pre‑submit UI check: warn inline if a case‑insensitive match exists.
+
+**Files:**
+- Change: `web/lib/validation/tags.ts` (normalize input)
+- Change: `web/app/admin/tags/actions.ts` (error message)
+- Change: `web/app/admin/tags/tag-manager.tsx` (inline notice before submit)
+- Change: `web/app/admin/tags/AdminCreateTagForm.tsx` (mirror inline notice)
+
+Tests: Unit test normalization; create "  Computer   Vision " → saved as "Computer Vision"; casing duplicate blocked.
+
+**Status:** Not Started
+
+---
+
+### Step 3: Enforce max 10 tags for projects (tech+category)
+**Goal:** Limit total selected tags to at most 10 across technology and category for projects.
+
+**What we are doing:** Prevent picking too many tags so project pages stay readable. Show a counter and stop at 10.
+
+**Technical details:**
+- Server validation: add `.superRefine` to `createProjectSchema` to enforce `techTagIds.length + categoryTagIds.length ≤ 10` with a single clear error message.
+- UI guardrails: show a live counter (e.g., "7/10 selected"); disable additional chips once at 10; allow deselection.
+- No changes to server actions contract beyond error message text.
+
+**Files:**
+- Change: `web/app/projects/schema.ts`
+- Change: `web/app/projects/new/page.tsx`
+- Potentially affected: `web/app/projects/actions.ts` (surface validation errors), `web/tests/projects.schema.test.ts`
+
+Tests: Schema accepts 10 tags, rejects 11; UI disables 11th chip and shows counter.
+
+**Status:** Not Started
+
+---
+
+### Step 4: Enforce max 10 tags for collaborations (tech+category only)
+**Goal:** Limit total selected tags to at most 10 across technology and category for collaborations (project types are not counted).
+
+**What we are doing:** Same cap as projects, but project types (like personal, open source) don't count.
+
+**Technical details:**
+- Server validation: add `.superRefine` to `createCollabSchema` to enforce `techTagIds.length + categoryTagIds.length ≤ 10`.
+- UI guardrails: show a live counter; disable chips once the 10 limit is reached; allow deselection.
+
+**Files:**
+- Change: `web/app/collaborations/schema.ts`
+- Change: `web/app/collaborations/new/page.tsx`
+- Potentially affected: `web/app/collaborations/actions.ts`, new test file `web/tests/collabs.schema.cap.test.ts`
+
+Tests: Schema accepts 10 tags, rejects 11; project types ignored; UI disables 11th tag.
+
+**Status:** Not Started
+
+---
+
+### Step 5: Light tag‑picker UX refinements (both forms)
+**Goal:** Keep forms tidy as the vocabulary grows: add a small search, suggested tags, and scrollable lists with counters.
+
+**What we are doing:** Add a tiny search box to filter tags, show a short "Suggested" list at the top, and make long lists scroll. Also show "X/10 selected" and stop selecting more when full.
+
+**Technical details:**
+- Per facet (Technology, Category):
+  - Filter input that narrows the local chip list (client‑side only).
+  - A curated "Suggested" subsection (first 8–12 curated tags per facet) above the full list.
+  - Wrap full list in a container with `max-height` and `overflow-y: auto`.
+  - Selection counter and chip disabling when at cap.
+- No API/schema changes.
+
+**Files:**
+- Change: `web/app/projects/new/page.tsx`
+- Change: `web/app/collaborations/new/page.tsx`
+
+Tests: Render test verifies filter narrows chips; suggested renders; scroll container present; manual counter/disable works.
+
+**Status:** Not Started
+
+---
+
+### Step 6: Curate and seed initial tag lists; review existing
+**Goal:** Provide a generally understandable set of technology and category tags; review current tags without renaming.
+
+**What we are doing:** Use well‑known sources to draft simple tag lists people understand (e.g., NLP, Computer Vision, Education, Finance). Add them to seeds and check what we already have.
+
+**Technical details:**
+- Research references: Hugging Face Tasks, Papers with Code areas/tasks, Product Hunt Topics.
+- Draft concise lists (e.g., ~12–20 per facet). Submit for review before seeding.
+- Append to `seed_mvp.sql` with `on conflict do nothing` (non‑destructive).
+- Generate a brief report of current tags: case‑insensitive dupes and coverage gaps; include in PR description only (no renames).
+
+**Files:**
+- Change: `supabase/seed/seed_mvp.sql`
+- Add (optional): short report attached in PR description (no repo file changes required)
+
+Tests: Re-run seeds idempotently; curated tags visible in UI; existing tags unchanged; PR report lists dupes/gaps.
+
+**Status:** Not Started
+
+---
+
+### Step 7: Tests
+**Goal:** Ensure validation and basic UX behavior are covered.
+
+**What we are doing:** Add tests so we don’t accidentally break the caps or tag validation later.
+
+**Technical details:**
+- Project cap tests: extend `projects.schema.test.ts` to check pass/fail around 10.
+- Collaboration cap tests: add `collabs.schema.cap.test.ts` (new) for 10‑tag limit excluding project types.
+- Tag validation tests: extend `tags.validation.test.ts` for normalization and case‑insensitive duplicate messaging (unit level).
+
+**Files:**
+- Change: `web/tests/projects.schema.test.ts`
+- Add: `web/tests/collabs.schema.cap.test.ts`
+- Change: `web/tests/tags.validation.test.ts`
+
+Tests: `pnpm test` runs new cases; they pass and fail appropriately when constraints are violated.
+
+**Status:** Not Started
+
+---
+
+### Step 8: Documentation & Changelog
+**Goal:** Keep specs and schema docs accurate; add user‑visible note.
+
+**What we are doing:** Update our manuals so future devs know about the new rules and users see what changed.
+
+**Technical details:**
+- `docs/MVP_TECH_SPEC.md`: mark Stage 14 as done; document 10‑tag cap and CI uniqueness.
+- `supabase/schema.md`: add the new index and rationale.
+- `docs/SERVER_ACTIONS.md`: note validation errors for tag caps.
+- `CHANGELOG.md` under Unreleased: summarize user‑visible changes.
+
+**Files:**
+- Change: `docs/MVP_TECH_SPEC.md`, `supabase/schema.md`, `docs/SERVER_ACTIONS.md`, `CHANGELOG.md`
+
+Tests: Manual doc review; ensure caps and CI uniqueness documented; changelog entry present.
+
+**Status:** In Progress
+
+---
+
+### Step 9: QA (lint/build/tests + manual smoke)
+**Goal:** Ensure everything is green and UX is smooth.
+
+**What we are doing:** Run checks and click through forms to confirm the experience feels right.
+
+**Technical details:**
+- Run `pnpm lint && pnpm test` locally; fix failures.
+- Manual: Admin adds a casing variant → UI warns; DB blocks with friendly error. Project/Collab forms show suggested tags, filter works, lists scroll, and selection caps at 10.
+
+**Files:**
+- No new files; verify changes across touched files.
+Tests: `pnpm lint && pnpm test`; manual Admin duplicate attempt; forms show filter/suggest/scroll and cap at 10.
+
+**Status:** Not Started
+
+---
+
+## Acceptance Criteria
+
+- Database rejects case‑insensitive duplicate tags (`unique(type, lower(name))` in place).
+- Admin tag creation warns for case‑insensitive duplicates and shows a friendly error if submitted.
+- Project and Collaboration forms:
+  - Show a "Suggested" subsection for each facet, plus a scrollable full list.
+  - Provide a filter input per facet that narrows visible tags.
+  - Display a live counter and prevent selecting more than 10 total tags (tech+category). Collaboration cap excludes project types.
+- Curated initial tag lists appended to seeds; existing tags unchanged; brief review report provided in PR.
+- Tests added/updated and passing.
+- Docs updated: MVP spec, schema overview, server actions, and changelog.
+
+## Workflow
+
+At each step in 'Actionable and specific steps':
+
+- Explain clearly on what you are doing and the rationale behind with layman's term, and add detailed explanation if technical term is used. 
+- Inspect relevant code, documents, and ‘.cursorrules’ before making change.
+- Code the changes, and make sure codes are robust, reusable and modular. 
+- Identidy the files that the code would affect and prevent any bug.
+- Add testcases for the change. Then, make sure all testcases are passed.
+- Guide user to review the code changes and functionality change in UI.
+- After user's review and approval, update progress tracking and other relevant documents.
+- Lastly, commit and push changes to Github.
+- ONLY when everything above is done, proceed to the next step in ‘Actionable and specific steps’
+
+If you need help from user, give clear instructions to user on how to do it or what needs to be decided on.
+
+## Progress Tracking
+
+| Step | Status | Started | Completed | Notes |
+|------|--------|---------|-----------|-------|
+| 1. CI unique index | Not Started | — | — | Add migration + docs |
+| 2. Admin tag normalization + messaging | Not Started | — | — | Inline warning + error copy |
+| 3. Project 10‑tag cap | Not Started | — | — | Schema refine + UI counter/disable |
+| 4. Collaboration 10‑tag cap | Not Started | — | — | Exclude project types from cap |
+| 5. Tag‑picker UX (filter/suggest/scroll/counter) | Not Started | — | — | Both forms |
+| 6. Curate & seed + review existing | Not Started | — | — | Append seeds; PR review report |
+| 7. Tests | Not Started | — | — | Projects, Collabs, Tags validation |
+| 8. Docs & Changelog | Not Started | — | — | Spec, schema, actions, changelog |
+| 9. QA | Not Started | — | — | Lint/test + manual smoke |
+
+## Risk Mitigation
+
+**Data integrity**
+- CI unique index prevents duplicate tags differing by case; keep existing unique (name, type) to avoid accidental removal.
+- Seeds use `on conflict do nothing` to stay idempotent.
+
+**UX regressions**
+- Keep refinements minimal (client‑side filter, small suggested list, scroll, counter) with no API changes.
+- Disable chips above cap while allowing deselection; clear inline messaging.
+
+**Compatibility**
+- No breaking changes to server action contracts; only additional validation error possible for caps.
+- Admin UI changes are additive; existing admin flows continue to work.
+
+**Testing & rollout**
+- Add unit tests for schema refinements and validation.
+- Manual smoke on forms and admin page before merging.
+
+---
+
+**Last Updated:** 16/9/2025  
+**Next Review:** On implementation completion
+
+

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -252,9 +252,14 @@ Development Plan (MVP)
     - —
   - Done when: 401/403/409/500 show friendly guidance; errors reach logging backend with redaction; disclaimer shown once and respected; tests cover 500 path and rate-limit on report.
 
-- Stage 14 — Tag curation & validation tweaks — Planned
-  - Tasks: curate initial tag set in admin UI; enforce dedupe/casing; cap tags per item (e.g., ≤ 8 total).
-  - Done when: forms prevent dupes; curated tags visible; search behaves unchanged functionally.
+- Stage 14 — Tag curation & validation tweaks — In Progress
+  - Tasks: curate initial tag set in admin UI; enforce dedupe/casing; cap tags per item.
+  - Updates:
+    - Case-insensitive uniqueness enforced at DB: `unique(type, lower(name))`.
+    - Admin UI normalizes input (trim + collapse whitespace) and warns on CI duplicates with existing name.
+    - Caps: Projects ≤ 10 total tags (tech+category); Collaborations ≤ 10 total tags (tech+category; project types not counted).
+    - Forms show live counter and disable non-selected chips at cap; deselection always allowed.
+  - Done when: forms prevent dupes and over-selection; curated tags visible; search unaffected.
 
 - Stage 15 — Logos for projects & collaborations (list display) — Planned
   - Tasks: create storage buckets (`project-logos`, `collab-logos`) with RLS; add `request*LogoUpload` and `set*Logo` actions; UI to upload on create/edit; render logos with `next/image` in cards with fallback.

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -260,6 +260,7 @@ Development Plan (MVP)
     - Caps (per-facet): Projects Technology ≤ 5 & Category ≤ 3; Collaborations Technology ≤ 5 & Category ≤ 3 (project types not counted).
     - Forms use a compact combobox with quick‑pick chips and a searchable dropdown; live counters per facet; disabled chips when at cap; deselection always allowed.
   - Done when: forms prevent dupes and over-selection; curated tags visible; search unaffected. (Met)
+  - See also: `docs/UI_PATTERNS.md` for quick‑pick defaults and the rule that "Others" sorts last in tag dropdowns.
 
 Tag Sources & Curation (Stage 14)
 - We curated generally understandable tags from well-known taxonomies:

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -252,14 +252,22 @@ Development Plan (MVP)
     - —
   - Done when: 401/403/409/500 show friendly guidance; errors reach logging backend with redaction; disclaimer shown once and respected; tests cover 500 path and rate-limit on report.
 
-- Stage 14 — Tag curation & validation tweaks — In Progress
+- Stage 14 — Tag curation & validation tweaks — Completed
   - Tasks: curate initial tag set in admin UI; enforce dedupe/casing; cap tags per item.
   - Updates:
     - Case-insensitive uniqueness enforced at DB: `unique(type, lower(name))`.
     - Admin UI normalizes input (trim + collapse whitespace) and warns on CI duplicates with existing name.
     - Caps (per-facet): Projects Technology ≤ 5 & Category ≤ 3; Collaborations Technology ≤ 5 & Category ≤ 3 (project types not counted).
     - Forms use a compact combobox with quick‑pick chips and a searchable dropdown; live counters per facet; disabled chips when at cap; deselection always allowed.
-  - Done when: forms prevent dupes and over-selection; curated tags visible; search unaffected.
+  - Done when: forms prevent dupes and over-selection; curated tags visible; search unaffected. (Met)
+
+Tag Sources & Curation (Stage 14)
+- We curated generally understandable tags from well-known taxonomies:
+  - [Hugging Face — Tasks](https://huggingface.co/tasks)
+  - [Papers with Code — Tasks](https://paperswithcode.com/task)
+  - [Product Hunt — Topics](https://www.producthunt.com/topics)
+  - [LinkedIn — Industry codes](https://learn.microsoft.com/linkedin/shared/references/reference-tables/industry-codes)
+- Curated snapshot lives at `docs/tags/curated-tags.csv`. Seeds append with `on conflict do nothing` to avoid renames or duplicates.
 
 - Stage 15 — Logos for projects & collaborations (list display) — Planned
   - Tasks: create storage buckets (`project-logos`, `collab-logos`) with RLS; add `request*LogoUpload` and `set*Logo` actions; UI to upload on create/edit; render logos with `next/image` in cards with fallback.

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -257,8 +257,8 @@ Development Plan (MVP)
   - Updates:
     - Case-insensitive uniqueness enforced at DB: `unique(type, lower(name))`.
     - Admin UI normalizes input (trim + collapse whitespace) and warns on CI duplicates with existing name.
-    - Caps: Projects ≤ 10 total tags (tech+category); Collaborations ≤ 10 total tags (tech+category; project types not counted).
-    - Forms show live counter and disable non-selected chips at cap; deselection always allowed.
+    - Caps (per-facet): Projects Technology ≤ 5 & Category ≤ 3; Collaborations Technology ≤ 5 & Category ≤ 3 (project types not counted).
+    - Forms use a compact combobox with quick‑pick chips and a searchable dropdown; live counters per facet; disabled chips when at cap; deselection always allowed.
   - Done when: forms prevent dupes and over-selection; curated tags visible; search unaffected.
 
 - Stage 15 — Logos for projects & collaborations (list display) — Planned

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -63,7 +63,7 @@ Errors
 
 Validation (UX)
 - Respect limits: Title ≤80, Tagline ≤140, Description ≤4000; URLs must be `http/https`.
-- Tag rules: at least one technology and one category.
+- Tag rules: at least one technology and one category. Caps: Projects ≤ 10 total (tech+category); Collaborations ≤ 10 total (tech+category; project types not counted).
 - Comments/Replies: 1–1000 chars; reply allowed only 1 level.
 - Friendly errors: 401/403/409 with actionable messages; retry for 500.
  - Rate-limited actions include a friendly message plus optional cooldown seconds.

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -63,7 +63,10 @@ Errors
 
 Validation (UX)
 - Respect limits: Title ≤80, Tagline ≤140, Description ≤4000; URLs must be `http/https`.
-- Tag rules: at least one technology and one category. Caps: Projects ≤ 10 total (tech+category); Collaborations ≤ 10 total (tech+category; project types not counted).
+- Tag rules: at least one technology and one category.
+- Caps (per-facet):
+  - Projects: Technology ≤ 5; Category ≤ 3.
+  - Collaborations: Technology ≤ 5; Category ≤ 3. Project types do not count toward caps.
 - Comments/Replies: 1–1000 chars; reply allowed only 1 level.
 - Friendly errors: 401/403/409 with actionable messages; retry for 500.
  - Rate-limited actions include a friendly message plus optional cooldown seconds.

--- a/docs/UI_PATTERNS.md
+++ b/docs/UI_PATTERNS.md
@@ -40,6 +40,8 @@ Purpose: Concise, reusable UI patterns used across the MVP. Keep this scoped to 
   - Selected colors: Technology (blue), Category (green). Do not convey meaning by color alone; include text/labels.
   - Caps: Technology ≤ 5; Category ≤ 3. Disable non‑selected options at cap; allow deselection always.
   - Keyboard: ArrowDown opens; Enter selects; Escape closes; focus returns to input.
+  - Sorting: options are alphabetical; any tag named "Others" is forced to the bottom for clarity.
+  - Defaults (current quick‑picks): Technology → Agents, LLM, Speech, Vibe Coding, Fine‑tuning. Category → Productivity, Education/ Study tools, Content/Media, Research.
 
 ## Character Counters and Limits
 

--- a/docs/UI_PATTERNS.md
+++ b/docs/UI_PATTERNS.md
@@ -35,6 +35,12 @@ Purpose: Concise, reusable UI patterns used across the MVP. Keep this scoped to 
   - Hiring: black background, white text, solid border.
   - No longer hiring: white background, gray text, outlined border.
 
+- Tag Pickers (projects & collaborations)
+  - Quick‑pick chips (curated) above a searchable combobox.
+  - Selected colors: Technology (blue), Category (green). Do not convey meaning by color alone; include text/labels.
+  - Caps: Technology ≤ 5; Category ≤ 3. Disable non‑selected options at cap; allow deselection always.
+  - Keyboard: ArrowDown opens; Enter selects; Escape closes; focus returns to input.
+
 ## Character Counters and Limits
 
 - Counters appear to the right of field labels or in compact helper text below inputs.

--- a/docs/tags/curated-tags.csv
+++ b/docs/tags/curated-tags.csv
@@ -1,0 +1,46 @@
+facet,name
+technology,LLM
+technology,NLP
+technology,Computer Vision
+technology,Agents
+technology,RAG
+technology,Multimodal
+technology,Speech
+technology,Traditional ML
+technology,Data Science
+technology,Data Analytics
+technology,Model Training
+technology,Fine-tuning
+technology,MLOps
+technology,Vibe Coding
+technology,On-device AI (Edge AI)
+technology,Embedded/IoT
+technology,Brain-Computer Interface (BCI)
+technology,Others
+category,Productivity
+category,Education
+category,Finance
+category,Healthcare
+category,Developer Tools
+category,Social
+category,Content/Media
+category,Research
+category,Sports
+category,Marketing
+category,Business/Management
+category,Computer Science
+category,Mathematics
+category,Physics
+category,Chemistry
+category,Biology
+category,Psychology
+category,Economics
+category,Engineering
+category,Web3/Crypto
+category,Design
+category,Architecture
+category,Travel
+category,Health & Fitness
+category,Education/ Study tools
+category,Hardware & IoT
+category,Others

--- a/supabase/migrations/20250916000000_add_ci_unique_tags.sql
+++ b/supabase/migrations/20250916000000_add_ci_unique_tags.sql
@@ -1,0 +1,11 @@
+-- Stage 14: Enforce case-insensitive uniqueness for tags (type, lower(name))
+-- Safe to run multiple times using IF NOT EXISTS semantics in create index
+
+do $$ begin
+  perform 1 from pg_indexes where schemaname = 'public' and indexname = 'uq_tags_type_lower_name';
+  if not found then
+    execute 'create unique index uq_tags_type_lower_name on public.tags (type, lower(name))';
+  end if;
+end $$;
+
+

--- a/supabase/migrations/20250918120000_remap_education_to_study_tools.sql
+++ b/supabase/migrations/20250918120000_remap_education_to_study_tools.sql
@@ -1,0 +1,50 @@
+-- Purpose: Remap category tag 'Education' to 'Education/ Study tools' and delete the old tag.
+-- Notes:
+-- - Idempotent: safe to run multiple times.
+-- - Seeds should no longer include ('Education','category') to avoid re-introducing the old tag.
+
+-- 1) Ensure target tag exists
+insert into tags (name, type) values ('Education/ Study tools', 'category')
+on conflict (name, type) do nothing;
+
+-- 2) Remap references from 'Education' -> 'Education/ Study tools' and delete old tag
+do $$
+declare
+  old_id int;
+  new_id int;
+begin
+  select id into old_id from tags where type = 'category' and lower(name) = 'education';
+  select id into new_id from tags where type = 'category' and name = 'Education/ Study tools';
+
+  if old_id is null then
+    -- Nothing to do
+    return;
+  end if;
+  if new_id is null then
+    raise exception 'Target tag Education/ Study tools missing';
+  end if;
+
+  -- De-duplicate to avoid (project_id, tag_id) PK conflicts
+  delete from project_tags pt
+  using project_tags dup
+  where pt.project_id = dup.project_id
+    and pt.tag_id = old_id
+    and dup.tag_id = new_id;
+
+  -- Remap project tag links
+  update project_tags
+  set tag_id = new_id
+  where tag_id = old_id;
+
+  -- If collaboration_tags exists in your project, you can enable analogous steps:
+  -- delete from collaboration_tags ct using collaboration_tags dup
+  -- where ct.collaboration_id = dup.collaboration_id
+  --   and ct.tag_id = old_id
+  --   and dup.tag_id = new_id;
+  -- update collaboration_tags set tag_id = new_id where tag_id = old_id;
+
+  -- Remove the old tag
+  delete from tags where id = old_id;
+end $$;
+
+

--- a/supabase/schema.md
+++ b/supabase/schema.md
@@ -31,6 +31,7 @@ Indexes (key)
  - comments(parent_comment_id, created_at asc)
  - comment_upvotes(comment_id)
 - tags(type, name)
+- uq_tags_type_lower_name unique(type, lower(name)) — prevents case-insensitive duplicates (e.g., 'nlp' vs 'NLP')
 - project_tags(tag_id, project_id)
 
 RLS Summary

--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -90,6 +90,7 @@ create index if not exists idx_projects_owner on projects (owner_id);
 create index if not exists idx_comments_project on comments (project_id, created_at desc);
 create index if not exists idx_upvotes_project on project_upvotes (project_id);
 create index if not exists idx_tags_type_name on tags (type, name);
+create unique index if not exists uq_tags_type_lower_name on tags (type, lower(name));
 create index if not exists idx_project_tags_tag on project_tags (tag_id, project_id);
 
 -- Basic search support (case-insensitive)

--- a/supabase/seed/seed_mvp.sql
+++ b/supabase/seed/seed_mvp.sql
@@ -7,10 +7,52 @@ values
   ('NLP', 'technology'),
   ('Computer Vision', 'technology'),
   ('Agents', 'technology'),
-  ('Education', 'category'),
+  --('Education', 'category'), (deleted)
   ('Finance', 'category'),
   ('Productivity', 'category'),
   ('Healthcare', 'category')
+on conflict (name, type) do nothing;
+
+-- Stage 14 curation: additional technology/category tags (idempotent)
+insert into tags (name, type)
+values
+  -- Technology (additions)
+  ('RAG', 'technology'),
+  ('Multimodal', 'technology'),
+  ('Speech', 'technology'),
+  ('Traditional ML', 'technology'),
+  ('Data Science', 'technology'),
+  ('Data Analytics', 'technology'),
+  ('Model Training', 'technology'),
+  ('Fine-tuning', 'technology'),
+  ('MLOps', 'technology'),
+  ('Vibe Coding', 'technology'),
+  ('On-device AI (Edge AI)', 'technology'),
+  ('Embedded/IoT', 'technology'),
+  ('Brain-Computer Interface (BCI)', 'technology'),
+  ('Others', 'technology'),
+
+  -- Category (additions)
+  ('Developer Tools', 'category'),
+  ('Social', 'category'),
+  ('Content/Media', 'category'),
+  ('Research', 'category'),
+  ('Sports', 'category'),
+  ('Marketing', 'category'),
+  ('Business/Management', 'category'),
+  ('Computer Science', 'category'),
+  ('Science', 'category'),
+  ('Mental Health & Psychology', 'category'),
+  ('Economics', 'category'),
+  ('Engineering', 'category'),
+  ('Web3/Crypto', 'category'),
+  ('Design', 'category'),
+  ('Architecture', 'category'),
+  ('Travel', 'category'),
+  ('Health & Fitness', 'category'),
+  ('Education/ Study tools', 'category'),
+  ('Hardware & IoT', 'category'),
+  ('Others', 'category')
 on conflict (name, type) do nothing;
 
 -- Optionally add a sample collaboration post via the app once auth is configured.

--- a/web/app/admin/tags/AdminCreateTagForm.tsx
+++ b/web/app/admin/tags/AdminCreateTagForm.tsx
@@ -1,20 +1,27 @@
 "use client"
 
 import { useActionState } from "react"
+import { useState, useMemo } from "react"
 import { createTag, type CreateTagState } from "./actions"
 import { Input } from "@/components/ui/input"
 import { Button } from "@/components/ui/button"
 import { Select } from "@/components/ui/select"
+import { normalizeTagName } from "@/lib/validation/tags"
 
 const initialState: CreateTagState = null
 
 export function AdminCreateTagForm() {
   const [state, formAction] = useActionState(createTag, initialState)
+  const [name, setName] = useState("")
+  const normalized = useMemo(() => normalizeTagName(name), [name])
   return (
     <form action={formAction} className="space-y-4 max-w-md">
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-2">Name</label>
-        <Input name="name" placeholder="e.g., LLMs" error={state?.fieldErrors?.name} />
+        <Input name="name" value={name} onChange={(e) => setName(e.target.value)} placeholder="e.g., LLMs" error={state?.fieldErrors?.name} />
+        {name && normalized !== name && (
+          <p className="text-xs text-gray-500 mt-1">Normalized: "{normalized}"</p>
+        )}
       </div>
       <div>
         <label className="block text-sm font-medium text-gray-700 mb-2">Type</label>

--- a/web/app/admin/tags/actions.ts
+++ b/web/app/admin/tags/actions.ts
@@ -3,7 +3,7 @@
 import { revalidatePath } from "next/cache"
 import { isAdmin } from "@/lib/server/admin"
 import { getServiceSupabase } from "@/lib/supabaseService"
-import { validateTagInput } from "@/lib/validation/tags"
+import { validateTagInput, normalizeTagName } from "@/lib/validation/tags"
 import type { Tag } from "@/lib/types"
 
 export type CreateTagState = { fieldErrors?: Record<string, string>; formError?: string; success?: boolean; tag?: Tag } | null
@@ -12,7 +12,7 @@ export async function createTag(_prev: CreateTagState, formData: FormData): Prom
   const ok = await isAdmin()
   if (!ok) return { formError: "unauthorized" }
 
-  const name = String(formData.get("name") || "")
+  const name = normalizeTagName(String(formData.get("name") || ""))
   const type = String(formData.get("type") || "") as "technology" | "category"
   const { fieldErrors } = validateTagInput(name, type)
   if (fieldErrors) return { fieldErrors }
@@ -26,7 +26,7 @@ export async function createTag(_prev: CreateTagState, formData: FormData): Prom
       .single()
     if (error) {
       if ((error as any).code === "23505" || (error.message || "").toLowerCase().includes("duplicate")) {
-        return { formError: "Tag already exists (name + type must be unique)." }
+        return { formError: "Tag already exists (case-insensitive)." }
       }
       return { formError: error.message || "Failed to create tag" }
     }

--- a/web/app/collaborations/new/page.tsx
+++ b/web/app/collaborations/new/page.tsx
@@ -59,6 +59,7 @@ export default function NewCollaborationPage() {
     const description = formData.description.trim()
     const contact = formData.contact.trim()
     const roles = lookingFor.filter((r) => r.role.trim().length > 0)
+    const tagsTotal = selectedTechTags.length + selectedCategoryTags.length
     return (
       title.length > 0 &&
       title.length <= 160 &&
@@ -67,6 +68,7 @@ export default function NewCollaborationPage() {
       contact.length > 0 &&
       selectedTechTags.length > 0 &&
       selectedCategoryTags.length > 0 &&
+      tagsTotal <= 10 &&
       roles.length >= 1 &&
       roles.length <= 5
     )
@@ -101,8 +103,18 @@ export default function NewCollaborationPage() {
   const updateRole = (idx: number, field: keyof (typeof lookingFor)[number], value: string | number) => {
     setLookingFor((prev) => prev.map((r, i) => (i === idx ? { ...r, [field]: value } : r)))
   }
-  const toggleTechTag = (id: number) => setSelectedTechTags((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
-  const toggleCategoryTag = (id: number) => setSelectedCategoryTags((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]))
+  const toggleTechTag = (id: number) =>
+    setSelectedTechTags((prev) => {
+      const total = (prev.includes(id) ? prev.filter((x) => x !== id).length : prev.length + 1) + selectedCategoryTags.length
+      if (!prev.includes(id) && total > 10) return prev
+      return prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    })
+  const toggleCategoryTag = (id: number) =>
+    setSelectedCategoryTags((prev) => {
+      const total = selectedTechTags.length + (prev.includes(id) ? prev.filter((x) => x !== id).length : prev.length + 1)
+      if (!prev.includes(id) && total > 10) return prev
+      return prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    })
 
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -306,26 +318,62 @@ export default function NewCollaborationPage() {
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-3">
             Technology Tags * {errors.techTagIds && <span className="text-red-600">({errors.techTagIds})</span>}
+            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
           </label>
           <div className="flex flex-wrap gap-2">
-            {technology.map((tag) => (
-              <button key={tag.id} type="button" onClick={() => toggleTechTag(tag.id)} className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${selectedTechTags.includes(tag.id) ? "bg-blue-100 text-blue-800 border border-blue-200" : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"}`}>
-                {tag.name}
-              </button>
-            ))}
+            {technology.map((tag) => {
+              const atCap = (selectedTechTags.length + selectedCategoryTags.length) >= 10
+              const selected = selectedTechTags.includes(tag.id)
+              const disabled = !selected && atCap
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleTechTag(tag.id)}
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                    selected
+                      ? "bg-blue-100 text-blue-800 border border-blue-200"
+                      : disabled
+                        ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
+                  }`}
+                  disabled={disabled}
+                >
+                  {tag.name}
+                </button>
+              )
+            })}
           </div>
         </div>
 
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-3">
             Category Tags * {errors.categoryTagIds && <span className="text-red-600">({errors.categoryTagIds})</span>}
+            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
           </label>
           <div className="flex flex-wrap gap-2">
-            {category.map((tag) => (
-              <button key={tag.id} type="button" onClick={() => toggleCategoryTag(tag.id)} className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${selectedCategoryTags.includes(tag.id) ? "bg-green-100 text-green-800 border border-green-200" : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"}`}>
-                {tag.name}
-              </button>
-            ))}
+            {category.map((tag) => {
+              const atCap = (selectedTechTags.length + selectedCategoryTags.length) >= 10
+              const selected = selectedCategoryTags.includes(tag.id)
+              const disabled = !selected && atCap
+              return (
+                <button
+                  key={tag.id}
+                  type="button"
+                  onClick={() => toggleCategoryTag(tag.id)}
+                  className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                    selected
+                      ? "bg-green-100 text-green-800 border border-green-200"
+                      : disabled
+                        ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
+                        : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
+                  }`}
+                  disabled={disabled}
+                >
+                  {tag.name}
+                </button>
+              )
+            })}
           </div>
         </div>
 

--- a/web/app/collaborations/new/page.tsx
+++ b/web/app/collaborations/new/page.tsx
@@ -320,9 +320,9 @@ export default function NewCollaborationPage() {
         </div>
 
         <TagMultiSelect
-          label={`Technology Tags * ${errors.techTagIds ? `(${errors.techTagIds})` : ""}`}
+          label={`Technology * ${errors.techTagIds ? `(${errors.techTagIds})` : ""}`}
           options={technology}
-          pinned={technology.filter((t) => ["LLM","NLP","Computer Vision","Agents"].includes(t.name))}
+          pinned={technology.filter((t) => ["Agents","LLM","Speech","Vibe Coding","Fine-tuning"].includes(t.name))}
           value={selectedTechTags}
           onChange={(next) => {
             const allowed = next.slice(0, 5)
@@ -334,9 +334,9 @@ export default function NewCollaborationPage() {
         />
 
         <TagMultiSelect
-          label={`Category Tags * ${errors.categoryTagIds ? `(${errors.categoryTagIds})` : ""}`}
+          label={`Category * ${errors.categoryTagIds ? `(${errors.categoryTagIds})` : ""}`}
           options={category}
-          pinned={category.filter((t) => ["Productivity","Education","Finance","Healthcare"].includes(t.name))}
+          pinned={category.filter((t) => ["Productivity","Education/ Study tools","Content/Media","Research"].includes(t.name))}
           value={selectedCategoryTags}
           onChange={(next) => {
             const allowed = next.slice(0, 3)

--- a/web/app/collaborations/new/page.tsx
+++ b/web/app/collaborations/new/page.tsx
@@ -13,6 +13,7 @@ import { useAuth, ensureServerSession } from "@/lib/api/auth"
 import { useTags } from "@/hooks/useTags"
 import { createCollabAction, type CreateCollabState } from "@/app/collaborations/actions"
 import { COLLAB_KIND_OPTIONS, PROJECT_TYPE_OPTIONS, STAGE_OPTIONS } from "@/lib/collabs/options"
+import { TagMultiSelect } from "@/components/ui/tag-multiselect"
 import { showToast } from "@/components/ui/toast"
 
 export default function NewCollaborationPage() {
@@ -38,6 +39,7 @@ export default function NewCollaborationPage() {
   ])
   const [selectedTechTags, setSelectedTechTags] = useState<number[]>([])
   const [selectedCategoryTags, setSelectedCategoryTags] = useState<number[]>([])
+  // filters handled within TagMultiSelect
 
   const errors = state?.fieldErrors || {}
 
@@ -115,6 +117,8 @@ export default function NewCollaborationPage() {
       if (!prev.includes(id) && total > 10) return prev
       return prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
     })
+
+  // handled internally by TagMultiSelect
 
   return (
     <div className="max-w-2xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
@@ -315,67 +319,33 @@ export default function NewCollaborationPage() {
           <Input id="remarks" name="remarks" value={formData.remarks} onChange={(e) => setFormData((p) => ({ ...p, remarks: e.target.value }))} placeholder="URL, Time Commitment, Additional Info" />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
-            Technology Tags * {errors.techTagIds && <span className="text-red-600">({errors.techTagIds})</span>}
-            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {technology.map((tag) => {
-              const atCap = (selectedTechTags.length + selectedCategoryTags.length) >= 10
-              const selected = selectedTechTags.includes(tag.id)
-              const disabled = !selected && atCap
-              return (
-                <button
-                  key={tag.id}
-                  type="button"
-                  onClick={() => toggleTechTag(tag.id)}
-                  className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-                    selected
-                      ? "bg-blue-100 text-blue-800 border border-blue-200"
-                      : disabled
-                        ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
-                        : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
-                  }`}
-                  disabled={disabled}
-                >
-                  {tag.name}
-                </button>
-              )
-            })}
-          </div>
-        </div>
+        <TagMultiSelect
+          label={`Technology Tags * ${errors.techTagIds ? `(${errors.techTagIds})` : ""}`}
+          options={technology}
+          pinned={technology.filter((t) => ["LLM","NLP","Computer Vision","Agents"].includes(t.name))}
+          value={selectedTechTags}
+          onChange={(next) => {
+            const allowed = next.slice(0, 5)
+            setSelectedTechTags(allowed)
+          }}
+          max={5}
+          placeholder="Add technology tag"
+          variant="tech"
+        />
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
-            Category Tags * {errors.categoryTagIds && <span className="text-red-600">({errors.categoryTagIds})</span>}
-            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {category.map((tag) => {
-              const atCap = (selectedTechTags.length + selectedCategoryTags.length) >= 10
-              const selected = selectedCategoryTags.includes(tag.id)
-              const disabled = !selected && atCap
-              return (
-                <button
-                  key={tag.id}
-                  type="button"
-                  onClick={() => toggleCategoryTag(tag.id)}
-                  className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-                    selected
-                      ? "bg-green-100 text-green-800 border border-green-200"
-                      : disabled
-                        ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
-                        : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
-                  }`}
-                  disabled={disabled}
-                >
-                  {tag.name}
-                </button>
-              )
-            })}
-          </div>
-        </div>
+        <TagMultiSelect
+          label={`Category Tags * ${errors.categoryTagIds ? `(${errors.categoryTagIds})` : ""}`}
+          options={category}
+          pinned={category.filter((t) => ["Productivity","Education","Finance","Healthcare"].includes(t.name))}
+          value={selectedCategoryTags}
+          onChange={(next) => {
+            const allowed = next.slice(0, 3)
+            setSelectedCategoryTags(allowed)
+          }}
+          max={3}
+          placeholder="Add category tag"
+          variant="category"
+        />
 
         {formData.projectTypes.map((v) => (
           <input key={`ptype-${v}`} type="hidden" name="projectTypes" value={v} />

--- a/web/app/collaborations/schema.ts
+++ b/web/app/collaborations/schema.ts
@@ -99,11 +99,19 @@ const createCollabBase = z.object({
 })
 
 export const createCollabSchema = createCollabBase.superRefine((value, ctx) => {
-    const total = (value.techTagIds?.length || 0) + (value.categoryTagIds?.length || 0)
-    if (total > 10) {
+    const techCount = value.techTagIds?.length || 0
+    const catCount = value.categoryTagIds?.length || 0
+    if (techCount > 5) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
-        message: "You can select at most 10 tags in total (technology + category)",
+        message: "You can select at most 5 technology tags",
+        path: ["techTagIds"],
+      })
+    }
+    if (catCount > 3) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "You can select at most 3 category tags",
         path: ["categoryTagIds"],
       })
     }

--- a/web/app/collaborations/schema.ts
+++ b/web/app/collaborations/schema.ts
@@ -32,7 +32,7 @@ export const lookingForItemSchema = z.object({
     .or(z.literal("")),
 })
 
-export const createCollabSchema = z.object({
+const createCollabBase = z.object({
   title: z
     .string()
     .trim()
@@ -98,9 +98,20 @@ export const createCollabSchema = z.object({
   categoryTagIds: z.array(z.number()).min(1, "At least one category tag is required"),
 })
 
+export const createCollabSchema = createCollabBase.superRefine((value, ctx) => {
+    const total = (value.techTagIds?.length || 0) + (value.categoryTagIds?.length || 0)
+    if (total > 10) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "You can select at most 10 tags in total (technology + category)",
+        path: ["categoryTagIds"],
+      })
+    }
+  })
+
 export type CreateCollabInput = z.infer<typeof createCollabSchema>
 
-export const updateCollabSchema = createCollabSchema.partial().extend({
+export const updateCollabSchema = createCollabBase.partial().extend({
   // Optional id hint for internal usage (not from client forms)
   id: z.string().uuid().optional(),
   isHiring: z.boolean().optional(),

--- a/web/app/projects/new/page.tsx
+++ b/web/app/projects/new/page.tsx
@@ -13,6 +13,7 @@ import { useAuth, ensureServerSession } from "@/lib/api/auth"
 import { useAnalytics } from "@/lib/analytics"
 import { showToast } from "@/components/ui/toast"
 import { useTags } from "@/hooks/useTags"
+import { TagMultiSelect } from "@/components/ui/tag-multiselect"
 import { createProjectAction, type CreateProjectState } from "@/app/projects/actions"
 
 export default function NewProjectPage() {
@@ -60,6 +61,8 @@ export default function NewProjectPage() {
       tagsTotal <= 10
     )
   }, [formData, selectedTechTags, selectedCategoryTags])
+
+  // Combobox variant handles filtering and alphabetical ordering internally
 
   // Show error toast when server action returns with formError
   useEffect(() => {
@@ -192,57 +195,34 @@ export default function NewProjectPage() {
           />
         </div>
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
-            Technology Tags * {errors.techTags && <span className="text-red-600">({errors.techTags})</span>}
-            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {technology.map((tag) => (
-              <button
-                key={tag.id}
-                type="button"
-                onClick={() => toggleTechTag(tag.id)}
-                className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-                  selectedTechTags.includes(tag.id)
-                    ? "bg-blue-100 text-blue-800 border border-blue-200"
-                    : (selectedTechTags.length + selectedCategoryTags.length) >= 10
-                      ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
-                }`}
-                disabled={!selectedTechTags.includes(tag.id) && (selectedTechTags.length + selectedCategoryTags.length) >= 10}
-              >
-                {tag.name}
-              </button>
-            ))}
-          </div>
-        </div>
+        <TagMultiSelect
+          label={`Technology Tags * ${errors.techTags ? `(${errors.techTags})` : ""}`}
+          options={technology}
+          pinned={technology.filter((t) => ["LLM","NLP","Computer Vision","Agents"].includes(t.name))}
+          value={selectedTechTags}
+          onChange={(next) => {
+            // enforce per-facet cap in UI guardrail
+            const allowed = next.slice(0, 5)
+            setSelectedTechTags(allowed)
+          }}
+          max={5}
+          placeholder="Add technology tag"
+          variant="tech"
+        />
 
-        <div>
-          <label className="block text-sm font-medium text-gray-700 mb-3">
-            Category Tags * {errors.categoryTags && <span className="text-red-600">({errors.categoryTags})</span>}
-            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
-          </label>
-          <div className="flex flex-wrap gap-2">
-            {category.map((tag) => (
-              <button
-                key={tag.id}
-                type="button"
-                onClick={() => toggleCategoryTag(tag.id)}
-                className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
-                  selectedCategoryTags.includes(tag.id)
-                    ? "bg-green-100 text-green-800 border border-green-200"
-                    : (selectedTechTags.length + selectedCategoryTags.length) >= 10
-                      ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
-                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
-                }`}
-                disabled={!selectedCategoryTags.includes(tag.id) && (selectedTechTags.length + selectedCategoryTags.length) >= 10}
-              >
-                {tag.name}
-              </button>
-            ))}
-          </div>
-        </div>
+        <TagMultiSelect
+          label={`Category Tags * ${errors.categoryTags ? `(${errors.categoryTags})` : ""}`}
+          options={category}
+          pinned={category.filter((t) => ["Productivity","Education","Finance","Healthcare"].includes(t.name))}
+          value={selectedCategoryTags}
+          onChange={(next) => {
+            const allowed = next.slice(0, 3)
+            setSelectedCategoryTags(allowed)
+          }}
+          max={3}
+          placeholder="Add category tag"
+          variant="category"
+        />
 
         {selectedTechTags.map((id) => (
           <input key={`tech-${id}`} type="hidden" name="techTagIds" value={id} />

--- a/web/app/projects/new/page.tsx
+++ b/web/app/projects/new/page.tsx
@@ -196,9 +196,9 @@ export default function NewProjectPage() {
         </div>
 
         <TagMultiSelect
-          label={`Technology Tags * ${errors.techTags ? `(${errors.techTags})` : ""}`}
+          label={`Technology * ${errors.techTags ? `(${errors.techTags})` : ""}`}
           options={technology}
-          pinned={technology.filter((t) => ["LLM","NLP","Computer Vision","Agents"].includes(t.name))}
+          pinned={technology.filter((t) => ["Agents","LLM","Speech","Vibe Coding","Fine-tuning"].includes(t.name))}
           value={selectedTechTags}
           onChange={(next) => {
             // enforce per-facet cap in UI guardrail
@@ -211,9 +211,9 @@ export default function NewProjectPage() {
         />
 
         <TagMultiSelect
-          label={`Category Tags * ${errors.categoryTags ? `(${errors.categoryTags})` : ""}`}
+          label={`Category * ${errors.categoryTags ? `(${errors.categoryTags})` : ""}`}
           options={category}
-          pinned={category.filter((t) => ["Productivity","Education","Finance","Healthcare"].includes(t.name))}
+          pinned={category.filter((t) => ["Productivity","Education/ Study tools","Content/Media","Research"].includes(t.name))}
           value={selectedCategoryTags}
           onChange={(next) => {
             const allowed = next.slice(0, 3)

--- a/web/app/projects/new/page.tsx
+++ b/web/app/projects/new/page.tsx
@@ -49,13 +49,15 @@ export default function NewProjectPage() {
     const description = formData.description.trim()
     const demoUrl = formData.demoUrl.trim()
 
+    const tagsTotal = selectedTechTags.length + selectedCategoryTags.length
     return (
       title.length > 0 && title.length <= 160 &&
       tagline.length > 0 && tagline.length <= 140 &&
       description.length > 0 && description.length <= 4000 &&
       demoUrl.length > 0 && /^https?:\/\//.test(demoUrl) &&
       selectedTechTags.length > 0 &&
-      selectedCategoryTags.length > 0
+      selectedCategoryTags.length > 0 &&
+      tagsTotal <= 10
     )
   }, [formData, selectedTechTags, selectedCategoryTags])
 
@@ -88,11 +90,19 @@ export default function NewProjectPage() {
   }
 
   const toggleTechTag = (tagId: number) => {
-    setSelectedTechTags((prev) => (prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]))
+    setSelectedTechTags((prev) => {
+      const total = (prev.includes(tagId) ? prev.filter((id) => id !== tagId).length : prev.length + 1) + selectedCategoryTags.length
+      if (!prev.includes(tagId) && total > 10) return prev
+      return prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]
+    })
   }
 
   const toggleCategoryTag = (tagId: number) => {
-    setSelectedCategoryTags((prev) => (prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]))
+    setSelectedCategoryTags((prev) => {
+      const total = selectedTechTags.length + (prev.includes(tagId) ? prev.filter((id) => id !== tagId).length : prev.length + 1)
+      if (!prev.includes(tagId) && total > 10) return prev
+      return prev.includes(tagId) ? prev.filter((id) => id !== tagId) : [...prev, tagId]
+    })
   }
 
   return (
@@ -185,6 +195,7 @@ export default function NewProjectPage() {
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-3">
             Technology Tags * {errors.techTags && <span className="text-red-600">({errors.techTags})</span>}
+            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
           </label>
           <div className="flex flex-wrap gap-2">
             {technology.map((tag) => (
@@ -195,8 +206,11 @@ export default function NewProjectPage() {
                 className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                   selectedTechTags.includes(tag.id)
                     ? "bg-blue-100 text-blue-800 border border-blue-200"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
+                    : (selectedTechTags.length + selectedCategoryTags.length) >= 10
+                      ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
                 }`}
+                disabled={!selectedTechTags.includes(tag.id) && (selectedTechTags.length + selectedCategoryTags.length) >= 10}
               >
                 {tag.name}
               </button>
@@ -207,6 +221,7 @@ export default function NewProjectPage() {
         <div>
           <label className="block text-sm font-medium text-gray-700 mb-3">
             Category Tags * {errors.categoryTags && <span className="text-red-600">({errors.categoryTags})</span>}
+            <span className="ml-2 text-xs text-gray-500">{selectedTechTags.length + selectedCategoryTags.length}/10 selected</span>
           </label>
           <div className="flex flex-wrap gap-2">
             {category.map((tag) => (
@@ -217,8 +232,11 @@ export default function NewProjectPage() {
                 className={`inline-flex items-center rounded-full px-3 py-1 text-sm font-medium transition-colors ${
                   selectedCategoryTags.includes(tag.id)
                     ? "bg-green-100 text-green-800 border border-green-200"
-                    : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
+                    : (selectedTechTags.length + selectedCategoryTags.length) >= 10
+                      ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
+                      : "bg-gray-100 text-gray-700 hover:bg-gray-200 border border-gray-200"
                 }`}
+                disabled={!selectedCategoryTags.includes(tag.id) && (selectedTechTags.length + selectedCategoryTags.length) >= 10}
               >
                 {tag.name}
               </button>

--- a/web/app/projects/schema.ts
+++ b/web/app/projects/schema.ts
@@ -31,6 +31,16 @@ export const createProjectSchema = z.object({
 	techTagIds: z.array(z.number()).min(1, "At least one technology tag is required"),
 	categoryTagIds: z.array(z.number()).min(1, "At least one category tag is required"),
 })
+	.superRefine((value, ctx) => {
+		const total = (value.techTagIds?.length || 0) + (value.categoryTagIds?.length || 0)
+		if (total > 10) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "You can select at most 10 tags in total (technology + category)",
+				path: ["categoryTagIds"],
+			})
+		}
+	})
 
 export type CreateProjectInput = z.infer<typeof createProjectSchema>
 

--- a/web/app/projects/schema.ts
+++ b/web/app/projects/schema.ts
@@ -32,11 +32,19 @@ export const createProjectSchema = z.object({
 	categoryTagIds: z.array(z.number()).min(1, "At least one category tag is required"),
 })
 	.superRefine((value, ctx) => {
-		const total = (value.techTagIds?.length || 0) + (value.categoryTagIds?.length || 0)
-		if (total > 10) {
+		const techCount = value.techTagIds?.length || 0
+		const catCount = value.categoryTagIds?.length || 0
+		if (techCount > 5) {
 			ctx.addIssue({
 				code: z.ZodIssueCode.custom,
-				message: "You can select at most 10 tags in total (technology + category)",
+				message: "You can select at most 5 technology tags",
+				path: ["techTagIds"],
+			})
+		}
+		if (catCount > 3) {
+			ctx.addIssue({
+				code: z.ZodIssueCode.custom,
+				message: "You can select at most 3 category tags",
 				path: ["categoryTagIds"],
 			})
 		}

--- a/web/components/ui/tag-multiselect.tsx
+++ b/web/components/ui/tag-multiselect.tsx
@@ -41,7 +41,14 @@ export function TagMultiSelect({ label, options, value, onChange, max, placehold
     if (excludePinnedFromDropdown && pinnedIds.size > 0) {
       pool = pool.filter((t) => !pinnedIds.has(t.id))
     }
-    const sorted = [...pool].sort((a, b) => a.name.localeCompare(b.name))
+    // Sort alphabetically, but force 'Others' to the bottom
+    const sorted = [...pool].sort((a, b) => {
+      const aIsOthers = a.name.toLowerCase() === "others"
+      const bIsOthers = b.name.toLowerCase() === "others"
+      if (aIsOthers && !bIsOthers) return 1
+      if (!aIsOthers && bIsOthers) return -1
+      return a.name.localeCompare(b.name)
+    })
     if (!q) return sorted
     return sorted.filter((t) => t.name.toLowerCase().includes(q))
   }, [options, byId, query])

--- a/web/components/ui/tag-multiselect.tsx
+++ b/web/components/ui/tag-multiselect.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useMemo, useRef, useState } from "react"
+import { sortWithOthersLast } from "@/lib/utils/tag-picker"
 import type { Tag } from "@/lib/types"
 
 type Props = {
@@ -41,14 +42,7 @@ export function TagMultiSelect({ label, options, value, onChange, max, placehold
     if (excludePinnedFromDropdown && pinnedIds.size > 0) {
       pool = pool.filter((t) => !pinnedIds.has(t.id))
     }
-    // Sort alphabetically, but force 'Others' to the bottom
-    const sorted = [...pool].sort((a, b) => {
-      const aIsOthers = a.name.toLowerCase() === "others"
-      const bIsOthers = b.name.toLowerCase() === "others"
-      if (aIsOthers && !bIsOthers) return 1
-      if (!aIsOthers && bIsOthers) return -1
-      return a.name.localeCompare(b.name)
-    })
+    const sorted = sortWithOthersLast(pool)
     if (!q) return sorted
     return sorted.filter((t) => t.name.toLowerCase().includes(q))
   }, [options, byId, query])

--- a/web/components/ui/tag-multiselect.tsx
+++ b/web/components/ui/tag-multiselect.tsx
@@ -1,0 +1,187 @@
+"use client"
+
+import { useMemo, useRef, useState } from "react"
+import type { Tag } from "@/lib/types"
+
+type Props = {
+  label: string
+  options: Tag[]
+  value: number[]
+  onChange: (next: number[]) => void
+  max: number
+  placeholder?: string
+  pinned?: Tag[]
+  excludePinnedFromDropdown?: boolean
+  variant?: "tech" | "category" | "neutral"
+}
+
+export function TagMultiSelect({ label, options, value, onChange, max, placeholder, pinned = [], excludePinnedFromDropdown = true, variant = "neutral" }: Props) {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState("")
+  const inputRef = useRef<HTMLInputElement | null>(null)
+
+  const byId = useMemo(() => new Set(value), [value])
+  const canAddMore = value.length < max
+  const pinnedIds = useMemo(() => new Set((pinned || []).map((p) => p.id)), [pinned])
+
+  const selectedChipClass = useMemo(() => {
+    switch (variant) {
+      case "tech":
+        return "bg-blue-100 text-blue-800 border border-blue-200"
+      case "category":
+        return "bg-green-100 text-green-800 border border-green-200"
+      default:
+        return "bg-gray-100 text-gray-700 border border-gray-200"
+    }
+  }, [variant])
+
+  const filtered = useMemo(() => {
+    const q = (query || "").toLowerCase()
+    let pool = options.filter((t) => !byId.has(t.id))
+    if (excludePinnedFromDropdown && pinnedIds.size > 0) {
+      pool = pool.filter((t) => !pinnedIds.has(t.id))
+    }
+    const sorted = [...pool].sort((a, b) => a.name.localeCompare(b.name))
+    if (!q) return sorted
+    return sorted.filter((t) => t.name.toLowerCase().includes(q))
+  }, [options, byId, query])
+
+  const add = (id: number, opts?: { openAfter?: boolean }) => {
+    if (!canAddMore) return
+    onChange([...value, id])
+    setQuery("")
+    const shouldOpen = opts?.openAfter ?? true
+    if (shouldOpen) {
+      setOpen(true)
+      inputRef.current?.focus()
+    }
+  }
+
+  const remove = (id: number) => {
+    onChange(value.filter((v) => v !== id))
+  }
+
+  return (
+    <div>
+      <div className="mb-2 text-sm font-medium text-gray-700">
+        {label} <span className="ml-2 text-xs text-gray-500">{value.length}/{max} selected</span>
+      </div>
+
+      <div className="flex flex-wrap gap-2 mb-2">
+        {/* Pinned quick-picks: shown always; toggle select; no × */}
+        {pinned.map((t) => {
+          const selected = byId.has(t.id)
+          const disabled = !selected && !canAddMore
+          return (
+            <button
+              key={`p-${t.id}`}
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation()
+                if (selected) {
+                  remove(t.id)
+                } else {
+                  // Selecting from quick-picks should NOT open the dropdown
+                  add(t.id, { openAfter: false })
+                }
+              }}
+              disabled={disabled}
+              className={`inline-flex items-center rounded-full px-3 py-1 text-sm ${
+                selected
+                  ? selectedChipClass
+                  : disabled
+                    ? "bg-gray-100 text-gray-400 border border-gray-200 cursor-not-allowed"
+                    : "bg-gray-50 text-gray-600 border border-gray-200 hover:bg-gray-100"
+              }`}
+            >
+              {t.name}
+            </button>
+          )
+        })}
+
+        {/* Dynamic selected (non-pinned) with removable × */}
+        {value
+          .filter((id) => !pinnedIds.has(id))
+          .map((id) => options.find((o) => o.id === id))
+          .filter(Boolean)
+          .map((t) => (
+            <button
+              key={`s-${t!.id}`}
+              type="button"
+              onClick={() => remove(t!.id)}
+              className={`inline-flex items-center rounded-full px-3 py-1 text-sm ${selectedChipClass} hover:opacity-90`}
+            >
+              {t!.name}
+              <span className="ml-2 text-gray-500">×</span>
+            </button>
+          ))}
+      </div>
+
+      <div
+        className="relative"
+        onClick={() => {
+          setOpen(true)
+          inputRef.current?.focus()
+        }}
+      >
+        <input
+          ref={inputRef}
+          type="text"
+          className="w-full rounded border border-gray-200 px-3 py-2 text-sm"
+          placeholder={placeholder || "Add tag"}
+          value={query}
+          onChange={(e) => {
+            setQuery(e.target.value)
+            setOpen(true)
+          }}
+          onFocus={() => setOpen(true)}
+          onBlur={() => {
+            // Defer to allow option click (which uses preventDefault on mousedown)
+            setTimeout(() => setOpen(false), 100)
+          }}
+          onKeyDown={(e) => {
+            if (e.key === "ArrowDown") setOpen(true)
+          }}
+        />
+        <button
+          type="button"
+          aria-label="Show options"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-500 hover:text-gray-700"
+          onMouseDown={(e) => { e.preventDefault(); e.stopPropagation() }}
+          onClick={(e) => {
+            e.stopPropagation()
+            setOpen((o) => !o)
+            inputRef.current?.focus()
+          }}
+        >
+          ▾
+        </button>
+
+        {open && (
+          <div className="absolute z-10 mt-1 max-h-64 w-full overflow-auto rounded-md border border-gray-200 bg-white shadow">
+            {filtered.length === 0 && (
+              <div className="px-3 py-2 text-sm text-gray-500">No matches</div>
+            )}
+            {filtered.map((t) => {
+              const disabled = !canAddMore
+              return (
+                <button
+                  key={t.id}
+                  type="button"
+                  onMouseDown={(e) => e.preventDefault()}
+                  onClick={() => add(t.id)}
+                  disabled={disabled}
+                  className={`block w-full text-left px-3 py-2 text-sm ${disabled ? "text-gray-400 cursor-not-allowed" : "hover:bg-gray-50"}`}
+                >
+                  {t.name}
+                </button>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+

--- a/web/lib/utils/tag-picker.ts
+++ b/web/lib/utils/tag-picker.ts
@@ -15,4 +15,15 @@ export function selectSuggested(tags: Tag[], count = 12): Tag[] {
   return (tags || []).slice(0, Math.max(0, count))
 }
 
+export function sortWithOthersLast(tags: Tag[]): Tag[] {
+  const isOthers = (name: string) => (name || "").toLowerCase() === "others"
+  return [...(tags || [])].sort((a, b) => {
+    const aIs = isOthers(a.name)
+    const bIs = isOthers(b.name)
+    if (aIs && !bIs) return 1
+    if (!aIs && bIs) return -1
+    return a.name.localeCompare(b.name)
+  })
+}
+
 

--- a/web/lib/utils/tag-picker.ts
+++ b/web/lib/utils/tag-picker.ts
@@ -1,0 +1,18 @@
+import type { Tag } from "@/lib/types"
+
+export function normalizeQuery(q: string): string {
+  return (q || "").trim().toLowerCase()
+}
+
+export function filterTags(tags: Tag[], query: string): Tag[] {
+  const q = normalizeQuery(query)
+  if (!q) return tags
+  return tags.filter((t) => t.name.toLowerCase().includes(q))
+}
+
+export function selectSuggested(tags: Tag[], count = 12): Tag[] {
+  // Heuristic: take first N since upstream lists are alphabetically sorted
+  return (tags || []).slice(0, Math.max(0, count))
+}
+
+

--- a/web/lib/validation/tags.ts
+++ b/web/lib/validation/tags.ts
@@ -1,6 +1,12 @@
+export function normalizeTagName(name: string): string {
+  const raw = String(name ?? "")
+  // Collapse any whitespace runs to a single space and trim ends
+  return raw.replace(/\s+/g, " ").trim()
+}
+
 export function validateTagInput(name: string, type: "technology" | "category") {
   const fieldErrors: Record<string, string> = {}
-  const trimmed = (name || "").trim()
+  const trimmed = normalizeTagName(name)
   if (!trimmed) {
     fieldErrors.name = "Name is required"
   } else if (trimmed.length > 50) {

--- a/web/tests/collabs.schema.cap.test.ts
+++ b/web/tests/collabs.schema.cap.test.ts
@@ -1,10 +1,10 @@
 import { describe, it, expect } from "vitest"
 
 describe("createCollabSchema tag cap", () => {
-  it("rejects more than 10 total tags (tech+category), ignoring project types", async () => {
+  it("rejects more than 5 tech or 3 category tags (ignore project types)", async () => {
     const { createCollabSchema } = await import("@/app/collaborations/schema")
     const tech = Array.from({ length: 6 }, (_, i) => i + 1)
-    const cat = Array.from({ length: 5 }, (_, i) => i + 100)
+    const cat = Array.from({ length: 4 }, (_, i) => i + 100)
     const { success, error } = createCollabSchema.safeParse({
       title: "A",
       affiliatedOrg: "",
@@ -15,10 +15,11 @@ describe("createCollabSchema tag cap", () => {
       contact: "me@example.com",
       remarks: "",
       techTagIds: tech,
-      categoryTagIds: cat, // 11 total
+      categoryTagIds: cat, // over both per-facet caps
     })
     expect(success).toBe(false)
-    expect(error?.issues.some((i) => String(i.message).includes("at most 10"))).toBe(true)
+    expect(error?.issues.some((i) => String(i.message).includes("at most 5 technology"))).toBe(true)
+    expect(error?.issues.some((i) => String(i.message).includes("at most 3 category"))).toBe(true)
   })
 })
 

--- a/web/tests/collabs.schema.cap.test.ts
+++ b/web/tests/collabs.schema.cap.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest"
+
+describe("createCollabSchema tag cap", () => {
+  it("rejects more than 10 total tags (tech+category), ignoring project types", async () => {
+    const { createCollabSchema } = await import("@/app/collaborations/schema")
+    const tech = Array.from({ length: 6 }, (_, i) => i + 1)
+    const cat = Array.from({ length: 5 }, (_, i) => i + 100)
+    const { success, error } = createCollabSchema.safeParse({
+      title: "A",
+      affiliatedOrg: "",
+      projectTypes: ["personal"],
+      description: "D",
+      stage: "mvp_development",
+      lookingFor: [{ role: "FE", amount: 1 }],
+      contact: "me@example.com",
+      remarks: "",
+      techTagIds: tech,
+      categoryTagIds: cat, // 11 total
+    })
+    expect(success).toBe(false)
+    expect(error?.issues.some((i) => String(i.message).includes("at most 10"))).toBe(true)
+  })
+})
+
+

--- a/web/tests/projects.schema.test.ts
+++ b/web/tests/projects.schema.test.ts
@@ -48,10 +48,10 @@ describe("createProjectSchema", () => {
 		expect(fields).toEqual(expect.arrayContaining(["title", "tagline", "description", "demoUrl", "sourceUrl"]))
 	})
 
-	it("rejects more than 10 total tags (tech+category)", async () => {
+	it("rejects more than 5 tech or 3 category tags", async () => {
 		const { createProjectSchema } = await import("@/app/projects/schema")
 		const tech = Array.from({ length: 6 }, (_, i) => i + 1)
-		const cat = Array.from({ length: 5 }, (_, i) => i + 100)
+		const cat = Array.from({ length: 4 }, (_, i) => i + 100)
 		const { success, error } = createProjectSchema.safeParse({
 			title: "A",
 			tagline: "B",
@@ -59,10 +59,11 @@ describe("createProjectSchema", () => {
 			demoUrl: "https://x.com",
 			sourceUrl: "",
 			techTagIds: tech,
-			categoryTagIds: cat, // 6 + 5 = 11
+			categoryTagIds: cat, // 6 tech (>5) and 4 category (>3)
 		})
 		expect(success).toBe(false)
-		expect(error?.issues.some((i) => String(i.message).includes("at most 10"))).toBe(true)
+		expect(error?.issues.some((i) => String(i.message).includes("at most 5 technology"))).toBe(true)
+		expect(error?.issues.some((i) => String(i.message).includes("at most 3 category"))).toBe(true)
 	})
 })
 

--- a/web/tests/projects.schema.test.ts
+++ b/web/tests/projects.schema.test.ts
@@ -47,6 +47,23 @@ describe("createProjectSchema", () => {
 		const fields = (error?.issues || []).map((i) => i.path[0])
 		expect(fields).toEqual(expect.arrayContaining(["title", "tagline", "description", "demoUrl", "sourceUrl"]))
 	})
+
+	it("rejects more than 10 total tags (tech+category)", async () => {
+		const { createProjectSchema } = await import("@/app/projects/schema")
+		const tech = Array.from({ length: 6 }, (_, i) => i + 1)
+		const cat = Array.from({ length: 5 }, (_, i) => i + 100)
+		const { success, error } = createProjectSchema.safeParse({
+			title: "A",
+			tagline: "B",
+			description: "C",
+			demoUrl: "https://x.com",
+			sourceUrl: "",
+			techTagIds: tech,
+			categoryTagIds: cat, // 6 + 5 = 11
+		})
+		expect(success).toBe(false)
+		expect(error?.issues.some((i) => String(i.message).includes("at most 10"))).toBe(true)
+	})
 })
 
 

--- a/web/tests/tag-picker.util.test.ts
+++ b/web/tests/tag-picker.util.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from "vitest"
+
+describe("tag-picker utils", () => {
+  it("filters by substring case-insensitively", async () => {
+    const { filterTags } = await import("@/lib/utils/tag-picker")
+    const tags = [
+      { id: 1, name: "NLP", type: "technology" as const },
+      { id: 2, name: "Computer Vision", type: "technology" as const },
+    ]
+    expect(filterTags(tags as any, "vis").map((t) => t.name)).toEqual(["Computer Vision"])
+    expect(filterTags(tags as any, "").length).toBe(2)
+  })
+
+  it("selects first N suggested", async () => {
+    const { selectSuggested } = await import("@/lib/utils/tag-picker")
+    const tags = Array.from({ length: 20 }, (_, i) => ({ id: i + 1, name: `T${i + 1}`, type: "technology" as const }))
+    expect(selectSuggested(tags as any, 12).length).toBe(12)
+    expect(selectSuggested(tags as any, 0).length).toBe(0)
+  })
+})
+
+

--- a/web/tests/tag-picker.util.test.ts
+++ b/web/tests/tag-picker.util.test.ts
@@ -17,6 +17,17 @@ describe("tag-picker utils", () => {
     expect(selectSuggested(tags as any, 12).length).toBe(12)
     expect(selectSuggested(tags as any, 0).length).toBe(0)
   })
+
+  it("sorts with 'Others' last regardless of name position", async () => {
+    const { sortWithOthersLast } = await import("@/lib/utils/tag-picker")
+    const tags = [
+      { id: 1, name: "Others", type: "technology" as const },
+      { id: 2, name: "Agents", type: "technology" as const },
+      { id: 3, name: "LLM", type: "technology" as const },
+    ]
+    const sorted = sortWithOthersLast(tags as any)
+    expect(sorted.map((t) => t.name)).toEqual(["Agents", "LLM", "Others"])
+  })
 })
 
 

--- a/web/tests/tags.validation.test.ts
+++ b/web/tests/tags.validation.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest"
-import { validateTagInput } from "@/lib/validation/tags"
+import { validateTagInput, normalizeTagName } from "@/lib/validation/tags"
 
 describe("validateTagInput", () => {
   it("requires name", () => {
@@ -32,5 +32,9 @@ describe("validateTagInput", () => {
     const maxLength = "x".repeat(50)
     const { fieldErrors } = validateTagInput(maxLength, "category")
     expect(fieldErrors).toBeUndefined()
+  })
+
+  it("normalizes inner whitespace and trims ends", () => {
+    expect(normalizeTagName("  Computer   Vision ")).toBe("Computer Vision")
   })
 })


### PR DESCRIPTION
## Summary

Stage 14 delivers tag governance and UX improvements:
- Enforce case‑insensitive unique tags (DB + Admin UI)
- Per‑facet caps in forms (Technology ≤ 5; Category ≤ 3)
- New tag picker UX (quick‑pick chips + searchable combobox)
- Curated tag set (seeds + CSV provenance) and doc updates
- Small migration: remap `Education` → `Education/ Study tools`

Base branch: `main`
Feature branch: `feat/stage-14-tag-tweaks`
Merge: Squash & merge (per docs/GIT_BRANCHING.md)

## Scope of Changes

### Database
- Add CI unique index:
  - `uq_tags_type_lower_name unique(type, lower(name))`
- Migration to remap category:
  - `supabase/migrations/20250918120000_remap_education_to_study_tools.sql`
- Seeds (idempotent) expanded:
  - `supabase/seed/seed_mvp.sql`
  - New snapshot CSV: `docs/tags/curated-tags.csv`

### Validation & Server Actions
- Normalize tag names (trim + collapse spaces)
- Zod `.superRefine` per‑facet caps:
  - Projects: Technology ≤ 5; Category ≤ 3
  - Collabs: Technology ≤ 5; Category ≤ 3 (project types not counted)
- Clear error messages surfaced in forms

### UI/UX
- New `TagMultiSelect` combobox with quick‑picks
  - Quick‑pick sets:
    - Technology: Agents, LLM, Speech, Vibe Coding, Fine‑tuning
    - Category: Productivity, Education/ Study tools, Content/Media, Research
  - Dropdown is searchable and excludes selected/pinned
  - “Others” is always sorted last
  - Caps enforced per facet with counters; disable at cap
  - Caret toggles reliably; quick‑pick selection doesn’t open dropdown

### Docs
- `docs/MVP_TECH_SPEC.md`: Stage 14 Completed; per‑facet caps; link to UI patterns
- `docs/SERVER_ACTIONS.md`: Validation (UX) now lists per‑facet caps
- `supabase/schema.md`: Index `uq_tags_type_lower_name` documented
- `docs/UI_PATTERNS.md`: Tag picker pattern; quick‑pick defaults; “Others last”
- `docs/MVP implementation plan/stage 14.md`: Steps 1–9 Completed; acceptance criteria aligned; note on Education remap
- `CHANGELOG.md`: Stage 14 additions summarized

## How to Run

1) Install deps and test:
```bash
cd web
pnpm install --frozen-lockfile
pnpm test
```

2) Apply DB changes (one time on your Supabase project):
- Ensure schema is up-to-date (`supabase/schema.sql` if needed).
- Run migration:
  - `supabase/migrations/20250918120000_remap_education_to_study_tools.sql`
- Seed curated tags (idempotent):
  - `supabase/seed/seed_mvp.sql`

## Acceptance Checks

- Admin: creating case‑variant tags is blocked with a friendly message
- Project/Collab forms:
  - Tech and Category caps enforced (5/3) with counters and disabled additions at cap
  - Quick‑picks reflect the defaults above; selecting a quick‑pick doesn’t open the dropdown
  - Dropdown sorts “Others” last and filters by substring
- Seeds add curated tags without duplicates; CSV matches seeds
- All tests pass locally

## Known Limitations / Notes

- Repo‑wide lint shows pre‑existing warnings/errors outside this PR’s scope; files modified in this PR lint clean.
- Tag list is additive; rare renames/remaps handled via explicit migrations (example: Education → Education/ Study tools).

## Related Docs

- Tech Spec: `docs/MVP_TECH_SPEC.md`
- Server Actions: `docs/SERVER_ACTIONS.md`
- Schema: `supabase/schema.md`
- UI Patterns: `docs/UI_PATTERNS.md`
- Stage Plan: `docs/MVP implementation plan/stage 14.md`
- Branching: `docs/GIT_BRANCHING.md`

## Changelog

- Update `CHANGELOG.md` under `## [Unreleased]` — Stage 14: tag curation & validation (already included).