### PR TITLE
feat(stage-17): collaboration visibility (auth-only) — gate list/detail/search, RLS, sitemap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
+- Stage 17: RLS — collaborations are now auth-only for reads (DB enforced). Added migration and restructured `supabase/rls_policies.sql`; added policy assertion test.
 - Stage 16: Collaborations — unified search box and reusable FilterBar on `/collaborations` (project mode). Client shell in place to enable role mode split view next.
 - Stage 16: Analytics — `/collaborations` emits `search_performed` and `filter_apply` with `search_mode` (project|role), `role` in role mode, and unified tag/stage/type properties. Added `search_mode_change` event when toggling modes.
 - Stage 16: Roles suggestions API — `GET /api/roles/list` returns alphabetized role names from curated catalog.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ and this project adheres to Semantic Versioning (https://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Added
-- Stage 17: RLS — collaborations are now auth-only for reads (DB enforced). Added migration and restructured `supabase/rls_policies.sql`; added policy assertion test.
+- Stage 17: Collaboration visibility (auth-only)
+  - RLS: collaborations, tags, upvotes, roles, and comments are auth-only for SELECT; `roles_catalog` remains public. Policy assertions updated.
+  - Server/API: `listCollabs`/`getCollab` require session; `/api/collaborations/list` and `/get` return 401 for anonymous.
+  - UI: `/collaborations` and `/collaborations/[id]` show login-required screen when anonymous; navbar always shows Collaborations link; landing hides collab previews for anon and shows sign-in CTA; `/search` shows login-required card on collab tab for anon.
+  - SEO: `sitemap.xml` excludes collaborations.
 - Stage 16: Collaborations — unified search box and reusable FilterBar on `/collaborations` (project mode). Client shell in place to enable role mode split view next.
 - Stage 16: Analytics — `/collaborations` emits `search_performed` and `filter_apply` with `search_mode` (project|role), `role` in role mode, and unified tag/stage/type properties. Added `search_mode_change` event when toggling modes.
 - Stage 16: Roles suggestions API — `GET /api/roles/list` returns alphabetized role names from curated catalog.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -43,6 +43,9 @@ Collaboration visibility (Stage 17)
 - Reads for collaborations are auth-only (RLS enforced; server list/get require session; API returns 401 for anon).
 - `/collaborations` when anonymous renders a login-required screen with a Sign in button linking to `/auth/sign-in?redirectTo=/collaborations`.
 - Navbar continues to link to `/collaborations`; gating happens on the page.
+ - `/collaborations/[id]` shows a login-required screen for anonymous users.
+ - Landing page (`/`) does not fetch collaboration previews for anonymous users and shows a compact sign-in CTA instead.
+ - Search (`/search`): switching to the Collaborations tab while anonymous immediately shows a login-required card and skips the API call; placeholder text changes to “Search for Collaborations” when authenticated.
 
 Cookie sync for server actions (Profiles)
 - After the callback sets the session, the app calls `/api/profile/ensure`.

--- a/docs/AUTH.md
+++ b/docs/AUTH.md
@@ -39,6 +39,11 @@ References
 - Tech Spec: `docs/MVP_TECH_SPEC.md`
 - Env setup: `ops/ENVIRONMENT.md`
 
+Collaboration visibility (Stage 17)
+- Reads for collaborations are auth-only (RLS enforced; server list/get require session; API returns 401 for anon).
+- `/collaborations` when anonymous renders a login-required screen with a Sign in button linking to `/auth/sign-in?redirectTo=/collaborations`.
+- Navbar continues to link to `/collaborations`; gating happens on the page.
+
 Cookie sync for server actions (Profiles)
 - After the callback sets the session, the app calls `/api/profile/ensure`.
 - If the server hasn’t seen the auth cookies yet (fresh sign-in), the callback also sends the `access_token` and `refresh_token` once so the server can set the cookie via `supabase.auth.setSession(...)`.

--- a/docs/GIT_GUIDE.md
+++ b/docs/GIT_GUIDE.md
@@ -39,6 +39,9 @@ Purpose: keep `main` stable while shipping small, reviewable PRs per stage.
 
 ## Common commands
 ```bash
+# Go to the right directory
+cd "/Users/ahbo/Desktop/Builder's Pub"
+
 # Create a feature branch from main
 git checkout main && git pull
 git checkout -b feat/stage-2-auth

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -1,6 +1,6 @@
 # Stage 17 Implementation Plan: Collaboration visibility (auth-only)
 
-**Status:** Planned  
+**Status:** In Progress  
 **Started:** 24/9/2025
 **Completed:** —
 
@@ -58,7 +58,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Add server integration tests to assert anon select is denied (expect errors/empty) and authed select succeeds.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -167,7 +167,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Add a server-render test snapshot for anon showing the sign-in prompt instead of collab previews.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -318,7 +318,7 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 3. API routes auth | Completed | 24/9/2025 | 24/9/2025 | 401 for anon on list/get |
 | 4. Route gating (pages) | Completed | 24/9/2025 | 24/9/2025 | `/collaborations` + `[id]` show login‑required screens when anon |
 | 5. UI visibility (nav/footer/CTAs) | Completed | 24/9/2025 | 24/9/2025 | Navbar link always shown; page gates |
-| 6. Landing page gating | Not Started | — | — |  |
+| 6. Landing page gating | Completed | 24/9/2025 | 24/9/2025 | CTA shown for anon; no collab fetch |
 | 7. Search page gating | Not Started | — | — |  |
 | 8. Sitemap changes | Not Started | — | — |  |
 | 9. Tests (auth-only behavior) | Not Started | — | — |  |

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -125,7 +125,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Add route tests verifying login‑required screen for anon; ensure authed sessions render content (pending).
 
-**Status:** In Progress
+**Status:** Completed
 
 ---
 
@@ -316,7 +316,7 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 1. DB & RLS | Completed | 24/9/2025 | 24/9/2025 |  |
 | 2. Server: list/get require session | Completed | 24/9/2025 | 24/9/2025 |  |
 | 3. API routes auth | Completed | 24/9/2025 | 24/9/2025 | 401 for anon on list/get |
-| 4. Route gating (pages) | In Progress | 24/9/2025 | — | `/collaborations` shows login‑required screen; `[id]` pending |
+| 4. Route gating (pages) | Completed | 24/9/2025 | 24/9/2025 | `/collaborations` + `[id]` show login‑required screens when anon |
 | 5. UI visibility (nav/footer/CTAs) | Completed | 24/9/2025 | 24/9/2025 | Navbar link always shown; page gates |
 | 6. Landing page gating | Not Started | — | — |  |
 | 7. Search page gating | Not Started | — | — |  |

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -80,7 +80,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Update/extend server tests to expect 401/guard behavior on anon when invoking API wrappers; verify authed path still returns data.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -102,43 +102,43 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Add `web/tests/collabs.api.auth.test.ts` asserting 401 when anon for both endpoints.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
 ### Step 4: Route gating — `/collaborations` and `/collaborations/[id]`
-**Goal:** Redirect anonymous users to sign-in when they attempt to access collaboration pages.
+**Goal:** Prevent anonymous users from seeing collaboration content; provide a clear sign‑in path.
 
 **What we are doing:** Add server-side auth checks to both pages and redirect anonymous sessions to `/auth/sign-in?redirectTo=<original>`.
 
 **Technical details:**
 - File: `web/app/collaborations/page.tsx`
-  - At the top-level server component, get session via `getServerSupabase()`; if no user, `redirect('/auth/sign-in?redirectTo=/collaborations')`.
+  - Server checks session via `getServerSupabase()`; when anonymous, render a friendly login‑required screen with a Sign in button (linking to `/auth/sign-in?redirectTo=/collaborations`) instead of redirecting.
 - File: `web/app/collaborations/[id]/page.tsx`
-  - Do the same auth check before calling `getCollab(id)` (to avoid RLS failures and to keep flow consistent); `redirect('/auth/sign-in?redirectTo=/collaborations/<id>')`.
-- Optional: introduce a small `LoginRequired` server component for reusability (but keep changes minimal for now).
+  - To be gated in a follow‑up: current behavior falls back via data helper (no auth → no item).
+  - Option: mirror list page behavior with a login‑required screen.
 
 **Files:**
 - Change: `web/app/collaborations/page.tsx`
 - Change: `web/app/collaborations/[id]/page.tsx`
 - Potentially affected: `web/app/collaborations/CollaborationsClient.tsx` (no change expected; runs after server guard)
 
-**Tests:** Add route tests verifying redirects for anon; ensure authed sessions render content.
+**Tests:** Add route tests verifying login‑required screen for anon; ensure authed sessions render content (pending).
 
-**Status:** Not Started
+**Status:** In Progress
 
 ---
 
 ### Step 5: UI visibility — navbar, footer, and CTAs
-**Goal:** Avoid showing collaboration entry points to anonymous users.
+**Goal:** Keep navigation consistent while ensuring anon users are guided to sign in.
 
 **What we are doing:** Conditionally render collaboration links/CTAs based on auth state. On click while anon, direct to sign-in instead of the private page.
 
 **Technical details:**
 - File: `web/components/layout/navbar.tsx`
-  - Hide the `Collaborations` link when `!isAuthenticated`.
+  - Always show the `Collaborations` link; gating happens on the page with a login‑required screen.
 - File: `web/components/layout/footer.tsx`
-  - Hide `Collaborations`/`Post Collaboration` links for anonymous users.
+  - Optional: keep links visible; consider sign‑in CTAs where appropriate.
 - File: `web/app/profile/page.tsx`
   - Ensure `Post Collaboration` remains visible only for authed user contexts (already gated by profile route).
 
@@ -147,9 +147,9 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 - Change: `web/components/layout/footer.tsx`
 - Potentially affected: `web/app/page.tsx`, `web/app/search/page.tsx`
 
-**Tests:** Add a client-render test that, when `useAuth().isAuthenticated=false`, nav/footer do not show collaboration links/CTAs.
+**Tests:** Optional client‑render test that nav shows the link for anon; primary gating verified on the page.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -285,7 +285,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
   - API routes `/api/collaborations/list` and `/api/collaborations/get` return 401 for anonymous requests.
   - Database RLS denies `select` on collaboration tables for anon sessions.
 - UI behavior
-  - Navbar/footer do not show collaboration links for anonymous users.
+  - Navbar may show the `Collaborations` link for anonymous users; visiting `/collaborations` shows a login‑required screen with a Sign in button.
   - Landing page does not fetch or render collaboration previews for anonymous users; shows a clear sign-in CTA.
   - Search page does not fetch collaboration results when anonymous and shows a login-required state for that section.
 - SEO
@@ -313,11 +313,11 @@ If you need help from user, give clear instructions to user on how to do it or w
 
 | Step | Status | Started | Completed | Notes |
 |------|--------|---------|-----------|-------|
-| 1. DB & RLS | Not Started | — | — |  |
-| 2. Server: list/get require session | Not Started | — | — |  |
-| 3. API routes auth | Not Started | — | — |  |
-| 4. Route gating (pages) | Not Started | — | — |  |
-| 5. UI visibility (nav/footer/CTAs) | Not Started | — | — |  |
+| 1. DB & RLS | Completed | 24/9/2025 | 24/9/2025 |  |
+| 2. Server: list/get require session | Completed | 24/9/2025 | 24/9/2025 |  |
+| 3. API routes auth | Completed | 24/9/2025 | 24/9/2025 | 401 for anon on list/get |
+| 4. Route gating (pages) | In Progress | 24/9/2025 | — | `/collaborations` shows login‑required screen; `[id]` pending |
+| 5. UI visibility (nav/footer/CTAs) | Completed | 24/9/2025 | 24/9/2025 | Navbar link always shown; page gates |
 | 6. Landing page gating | Not Started | — | — |  |
 | 7. Search page gating | Not Started | — | — |  |
 | 8. Sitemap changes | Not Started | — | — |  |

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -207,7 +207,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Adjust existing sitemap test to ensure collab URLs are absent.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 
@@ -319,8 +319,8 @@ If you need help from user, give clear instructions to user on how to do it or w
 | 4. Route gating (pages) | Completed | 24/9/2025 | 24/9/2025 | `/collaborations` + `[id]` show login‑required screens when anon |
 | 5. UI visibility (nav/footer/CTAs) | Completed | 24/9/2025 | 24/9/2025 | Navbar link always shown; page gates |
 | 6. Landing page gating | Completed | 24/9/2025 | 24/9/2025 | CTA shown for anon; no collab fetch |
-| 7. Search page gating | Not Started | — | — |  |
-| 8. Sitemap changes | Not Started | — | — |  |
+| 7. Search page gating | Completed | 24/9/2025 | 24/9/2025 | Immediate login prompt; no API call when anon |
+| 8. Sitemap changes | Completed | 24/9/2025 | 24/9/2025 | Collab URLs excluded; tests updated |
 | 9. Tests (auth-only behavior) | Not Started | — | — |  |
 | 10. Docs & changelog | Not Started | — | — |  |
 | 11. Quality gate | Not Started | — | — |  |

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -17,7 +17,7 @@ Require authentication for `select` on collaboration-related tables (core rows, 
 Switch collaboration read helpers to use authenticated server client and require a valid session before fetching.
 
 ### 3. Route Gating (App Router)
-Gate `/collaborations` and `/collaborations/[id]` with a server-side auth check; redirect to sign-in with `redirectTo` when anonymous.
+Gate `/collaborations` and `/collaborations/[id]` with a server-side auth check; when anonymous, render a login‑required screen with a Sign in button (linking to sign-in with `redirectTo`).
 
 ### 4. API Gating
 Require auth for `/api/collaborations/list` and `/api/collaborations/get` (401 on anon).
@@ -109,7 +109,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 ### Step 4: Route gating — `/collaborations` and `/collaborations/[id]`
 **Goal:** Prevent anonymous users from seeing collaboration content; provide a clear sign‑in path.
 
-**What we are doing:** Add server-side auth checks to both pages and redirect anonymous sessions to `/auth/sign-in?redirectTo=<original>`.
+**What we are doing:** Add server-side auth checks to both pages and, when anonymous, render a login‑required screen with a Sign in button linking to `/auth/sign-in?redirectTo=<original>`.
 
 **Technical details:**
 - File: `web/app/collaborations/page.tsx`
@@ -359,7 +359,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 ## Acceptance Criteria
 
 - Auth-only access
-  - Anonymous users cannot access `/collaborations` or `/collaborations/[id]` (redirected to sign-in with `redirectTo`).
+  - Anonymous users cannot access `/collaborations` or `/collaborations/[id]` (a login‑required screen is shown with a Sign in button linking to sign-in with `redirectTo`).
   - API routes `/api/collaborations/list` and `/api/collaborations/get` return 401 for anonymous requests.
   - Database RLS denies `select` on collaboration tables for anon sessions.
 - UI behavior

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -1,0 +1,350 @@
+# Stage 17 Implementation Plan: Collaboration visibility (auth-only)
+
+**Status:** Planned  
+**Started:** 24/9/2025
+**Completed:** —
+
+## Overview
+
+Gate collaboration browsing and detail pages behind authentication. Anonymous users should not be able to view collaboration lists or individual collaboration details. Hide collaboration entry points in the UI when not signed in. Enforce database-level protections so anonymous sessions cannot select collaboration data. Keep the projects area fully public.
+
+## Tasks
+
+### 1. Database & RLS
+Require authentication for `select` on collaboration-related tables (core rows, tags join, upvotes, comments, roles index). Keep `roles_catalog` public read.
+
+### 2. Server Logic (Auth-only reads)
+Switch collaboration read helpers to use authenticated server client and require a valid session before fetching.
+
+### 3. Route Gating (App Router)
+Gate `/collaborations` and `/collaborations/[id]` with a server-side auth check; redirect to sign-in with `redirectTo` when anonymous.
+
+### 4. API Gating
+Require auth for `/api/collaborations/list` and `/api/collaborations/get` (401 on anon).
+
+### 5. UI Visibility
+Hide collaboration links/CTAs in navbar/footer/landing/search for anonymous users; avoid server fetching of collaboration data for anon.
+
+### 6. SEO & Sitemap
+Remove collaboration URLs from the sitemap since pages are auth-only; update tests accordingly.
+
+### 7. Tests & Docs
+Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs and changelog.
+
+
+## Actionable and Specific Steps
+
+### Step 1: DB & RLS — require auth for collaboration reads
+**Goal:** Prevent anonymous users from reading collaboration data at the database layer.
+
+**What we are doing:** Update RLS policies so `select` is allowed only when an authenticated user exists for collaboration-related tables. This ensures data access is blocked even if an API route is misconfigured.
+
+**Technical details:**
+- Create a new migration (timestamped) to update RLS policies for the following tables:
+  - `collaborations`: change `select` policy to require `auth.uid() is not null` AND `soft_deleted=false`.
+  - `collaboration_tags`: change `select` policy to require `auth.uid() is not null`.
+  - `collaboration_upvotes`: change `select` policy to require `auth.uid() is not null`.
+  - `collab_comments`: change `select` policy to require `auth.uid() is not null` AND `soft_deleted=false`.
+  - `collaboration_roles`: change `select` policy to require `auth.uid() is not null`.
+  - Keep `roles_catalog` public select.
+- Update `supabase/rls_policies.sql` accordingly to be the canonical policy source.
+
+**Files:**
+- Add: `supabase/migrations/20250923180000_collaborations_auth_only_select.sql` (run the command `TZ=Asia/Hong_Kong date +%Y%m%d%H%M%S` to get current time)
+- Change: `supabase/rls_policies.sql`
+- Change: `supabase/schema.md` (RLS Summary)
+- Potentially affected: `web/lib/server/collabs.ts` (reads will now require auth)
+- Potentially affected: tests that assumed public read of collaborations
+
+**Tests:** Add server integration tests to assert anon select is denied (expect errors/empty) and authed select succeeds.
+
+**Status:** Not Started
+
+---
+
+### Step 2: Server — use authenticated client and require session in list/get
+**Goal:** Ensure collaboration reads occur only under an authenticated session.
+
+**What we are doing:** Replace anonymous server client usage with the authenticated server client (`getServerSupabase()`) in `listCollabs`/`getCollab`. If there is no session, return an error (or let callers handle 401) instead of attempting a read.
+
+**Technical details:**
+- File: `web/lib/server/collabs.ts`
+  - At start of `listCollabs(params)`, call `getServerSupabase().auth.getUser()`; if no `user`, throw/return `{ items: [] }` with an auth error signal or raise an error consumed by callers.
+  - Replace `getAnonServerClient()` queries with the server client instance; maintain existing filtering/ranking logic.
+  - Same for `getCollab(id)`: require session before fetching; return `null` or throw on anon.
+  - Keep best-effort fallbacks for missing columns per existing pattern.
+
+**Files:**
+- Change: `web/lib/server/collabs.ts`
+- Potentially affected: `web/app/page.tsx`, `web/app/search/page.tsx` (they may use server helpers directly)
+
+**Tests:** Update/extend server tests to expect 401/guard behavior on anon when invoking API wrappers; verify authed path still returns data.
+
+**Status:** Not Started
+
+---
+
+### Step 3: API routes — enforce auth (401 when anon)
+**Goal:** Protect collaboration API endpoints from anonymous access.
+
+**What we are doing:** Add a server-side auth check in the API routes. If the request is unauthenticated, return `401 { error: 'unauthorized' }`.
+
+**Technical details:**
+- File: `web/app/api/collaborations/list/route.ts`
+  - Use `getServerSupabase()`; if no `auth.user`, return `NextResponse.json({ error: 'unauthorized' }, { status: 401 })`.
+  - Otherwise, forward to `listCollabs(params)`.
+- File: `web/app/api/collaborations/get/route.ts`
+  - Same pattern: require `auth.user` before calling `getCollab(id)`.
+
+**Files:**
+- Change: `web/app/api/collaborations/list/route.ts`
+- Change: `web/app/api/collaborations/get/route.ts`
+
+**Tests:** Add `web/tests/collabs.api.auth.test.ts` asserting 401 when anon for both endpoints.
+
+**Status:** Not Started
+
+---
+
+### Step 4: Route gating — `/collaborations` and `/collaborations/[id]`
+**Goal:** Redirect anonymous users to sign-in when they attempt to access collaboration pages.
+
+**What we are doing:** Add server-side auth checks to both pages and redirect anonymous sessions to `/auth/sign-in?redirectTo=<original>`.
+
+**Technical details:**
+- File: `web/app/collaborations/page.tsx`
+  - At the top-level server component, get session via `getServerSupabase()`; if no user, `redirect('/auth/sign-in?redirectTo=/collaborations')`.
+- File: `web/app/collaborations/[id]/page.tsx`
+  - Do the same auth check before calling `getCollab(id)` (to avoid RLS failures and to keep flow consistent); `redirect('/auth/sign-in?redirectTo=/collaborations/<id>')`.
+- Optional: introduce a small `LoginRequired` server component for reusability (but keep changes minimal for now).
+
+**Files:**
+- Change: `web/app/collaborations/page.tsx`
+- Change: `web/app/collaborations/[id]/page.tsx`
+- Potentially affected: `web/app/collaborations/CollaborationsClient.tsx` (no change expected; runs after server guard)
+
+**Tests:** Add route tests verifying redirects for anon; ensure authed sessions render content.
+
+**Status:** Not Started
+
+---
+
+### Step 5: UI visibility — navbar, footer, and CTAs
+**Goal:** Avoid showing collaboration entry points to anonymous users.
+
+**What we are doing:** Conditionally render collaboration links/CTAs based on auth state. On click while anon, direct to sign-in instead of the private page.
+
+**Technical details:**
+- File: `web/components/layout/navbar.tsx`
+  - Hide the `Collaborations` link when `!isAuthenticated`.
+- File: `web/components/layout/footer.tsx`
+  - Hide `Collaborations`/`Post Collaboration` links for anonymous users.
+- File: `web/app/profile/page.tsx`
+  - Ensure `Post Collaboration` remains visible only for authed user contexts (already gated by profile route).
+
+**Files:**
+- Change: `web/components/layout/navbar.tsx`
+- Change: `web/components/layout/footer.tsx`
+- Potentially affected: `web/app/page.tsx`, `web/app/search/page.tsx`
+
+**Tests:** Add a client-render test that, when `useAuth().isAuthenticated=false`, nav/footer do not show collaboration links/CTAs.
+
+**Status:** Not Started
+
+---
+
+### Step 6: Landing page — avoid fetching and hide previews for anon
+**Goal:** Prevent unnecessary collaboration queries and show a clear sign-in CTA on the landing page when anonymous.
+
+**What we are doing:** If no session on the server, do not call `listCollabs` for the homepage. Replace collaboration preview section with a small card prompting sign-in.
+
+**Technical details:**
+- File: `web/app/page.tsx`
+  - Use `getServerSupabase()`; when `!auth.user`, skip `listCollabs` calls; render a compact “Sign in to browse collaborators” card. Replace `Find Collaborators` and `View All` CTAs with a link to `/auth/sign-in?redirectTo=/collaborations`.
+
+**Files:**
+- Change: `web/app/page.tsx`
+
+**Tests:** Add a server-render test snapshot for anon showing the sign-in prompt instead of collab previews.
+
+**Status:** Not Started
+
+---
+
+### Step 7: Search page — hide collab results or show login-required state
+**Goal:** Keep search UX predictable; do not attempt collab fetches for anon.
+
+**What we are doing:** When anonymous, hide the collaborations tab/section or show a login-required notice instead of attempting API calls that will return 401.
+
+**Technical details:**
+- File: `web/app/search/page.tsx`
+  - On server, check session; if anon, do not call `listRealCollabs`; conditionally render a login-required card for the collaborations section/tab.
+  - If the page currently renders a unified view, guard the collab half only.
+
+**Files:**
+- Change: `web/app/search/page.tsx`
+
+**Tests:** Add a render test verifying no collab fetch for anon and that a login-required message is shown.
+
+**Status:** Not Started
+
+---
+
+### Step 8: Sitemap — remove collaboration URLs
+**Goal:** Ensure sitemap does not include private routes.
+
+**What we are doing:** Remove `/collaborations` and `/collaborations/[id]` URLs from `sitemap.xml` generation and update the test expectations.
+
+**Technical details:**
+- File: `web/app/sitemap.xml/route.ts`
+  - Remove `{ loc: `${base}/collaborations` }` and per-collaboration URLs. Keep projects and public pages.
+- File: `web/tests/sitemap.test.ts`
+  - Update assertions to no longer expect collab URLs.
+
+**Files:**
+- Change: `web/app/sitemap.xml/route.ts`
+- Change: `web/tests/sitemap.test.ts`
+
+**Tests:** Adjust existing sitemap test to ensure collab URLs are absent.
+
+**Status:** Not Started
+
+---
+
+### Step 9: Tests — RLS, redirects, API 401s, and UI visibility
+**Goal:** Validate end-to-end protections and UX for anonymous vs authenticated users.
+
+**What we are doing:** Add/adjust tests across layers to reflect auth-only behavior for collaborations.
+
+**Technical details:**
+- New tests:
+  - `web/tests/collabs.api.auth.test.ts` → 401 on anon for list/get.
+  - `web/tests/routes.collaborations.redirect.test.tsx` → pages redirect to sign-in when anon.
+  - `web/tests/navbar.auth-visibility.test.tsx` → nav/footer hide collaboration links on anon.
+  - Update existing tests that relied on public collab data or sitemap.
+
+**Files:**
+- Add: `web/tests/collabs.api.auth.test.ts`
+- Add: `web/tests/routes.collaborations.redirect.test.tsx`
+- Add: `web/tests/navbar.auth-visibility.test.tsx`
+- Change: `web/tests/sitemap.test.ts`
+
+**Tests:** As above; ensure green locally.
+
+**Status:** Not Started
+
+---
+
+### Step 10: Docs & changelog
+**Goal:** Document the auth-only collaboration policy and update specs.
+
+**What we are doing:** Update the MVP tech spec, server actions contracts, and schema RLS overview. Add a user-visible note to the changelog.
+
+**Technical details:**
+- Docs:
+  - `docs/MVP_TECH_SPEC.md` → Stage 17 moved from Planned to In Progress/Completed with details.
+  - `docs/SERVER_ACTIONS.md` → `listCollabs`/`getCollab` require auth; API routes return 401 when anon.
+  - `docs/AUTH.md` → note collaboration pages are auth-only; sign-in redirects preserved.
+  - `supabase/schema.md` → RLS summary updated to reflect auth-only selects for collaboration tables.
+  - `CHANGELOG.md` → add Unreleased bullet for this behavior change.
+
+**Files:**
+- Change: `docs/MVP_TECH_SPEC.md`
+- Change: `docs/SERVER_ACTIONS.md`
+- Change: `docs/AUTH.md`
+- Change: `supabase/schema.md`
+- Change: `CHANGELOG.md`
+
+**Tests:** Docs lint/review only.
+
+**Status:** Not Started
+
+---
+
+### Step 11: Quality gate — lint/build/tests
+**Goal:** Ensure a green state after changes.
+
+**What we are doing:** Run `pnpm install --frozen-lockfile` (if needed), then `pnpm lint`, `pnpm build`, and `pnpm test`. Fix any issues until green.
+
+**Technical details:**
+- Use pnpm via Corepack, as per repository rules.
+
+**Files:**
+- Potentially affected: Various (fixes only)
+
+**Tests:** CI/local runs should be fully green.
+
+**Status:** Not Started
+
+--- 
+
+## Acceptance Criteria
+
+- Auth-only access
+  - Anonymous users cannot access `/collaborations` or `/collaborations/[id]` (redirected to sign-in with `redirectTo`).
+  - API routes `/api/collaborations/list` and `/api/collaborations/get` return 401 for anonymous requests.
+  - Database RLS denies `select` on collaboration tables for anon sessions.
+- UI behavior
+  - Navbar/footer do not show collaboration links for anonymous users.
+  - Landing page does not fetch or render collaboration previews for anonymous users; shows a clear sign-in CTA.
+  - Search page does not fetch collaboration results when anonymous and shows a login-required state for that section.
+- SEO
+  - Sitemap excludes `/collaborations` and any `/collaborations/[id]` URLs.
+- Quality
+  - Tests updated/added and passing (RLS denial, redirects, API 401, UI visibility, sitemap adjustments).
+  - Lint and type checks pass; build is green.
+
+
+## Workflow
+
+At each step in 'Actionable and specific steps':
+
+- Explain clearly what we are doing and why (layman’s terms), add technical details when terms are used.
+- Inspect relevant code, documents, and `.cursorrules` before making changes.
+- Implement minimal, robust, reusable code; identify all affected files to prevent regressions.
+- Add/adjust tests; ensure all tests pass and build is green.
+- Guide user to review code/UI; after approval, update progress tracking and docs.
+- AFTER user's approval, commit with Conventional Commits and push. ONLY then proceed to the next step.
+
+If you need help from user, give clear instructions to user on how to do it or what needs to be decided on.
+
+
+## Progress Tracking
+
+| Step | Status | Started | Completed | Notes |
+|------|--------|---------|-----------|-------|
+| 1. DB & RLS | Not Started | — | — |  |
+| 2. Server: list/get require session | Not Started | — | — |  |
+| 3. API routes auth | Not Started | — | — |  |
+| 4. Route gating (pages) | Not Started | — | — |  |
+| 5. UI visibility (nav/footer/CTAs) | Not Started | — | — |  |
+| 6. Landing page gating | Not Started | — | — |  |
+| 7. Search page gating | Not Started | — | — |  |
+| 8. Sitemap changes | Not Started | — | — |  |
+| 9. Tests (auth-only behavior) | Not Started | — | — |  |
+| 10. Docs & changelog | Not Started | — | — |  |
+| 11. Quality gate | Not Started | — | — |  |
+
+## Risk Mitigation
+
+**Redirect loops:**
+- Ensure sign-in page does not bounce back to a gated route until session is established; only include `redirectTo` to the original path.
+
+**Caching & 401s:**
+- Mark collaboration API responses as `no-store` and ensure client wrappers do not cache 401s. Client code should not auto-retry when anon.
+
+**RLS rollout:**
+- Apply RLS changes and verify with tests before switching server helpers to authed clients. Keep fallbacks for missing columns as already implemented.
+
+**SEO impact:**
+- Removing collab URLs from the sitemap is expected; projects remain public. Add a brief note in the changelog explaining the change.
+
+**UX clarity:**
+- Show clear sign-in prompts where content is hidden; avoid dead links.
+
+---
+
+**Last Updated:** 24/9/2025  
+**Next Review:** After Step 4 (route gating) before UI adjustments
+
+

--- a/docs/MVP implementation plan/stage 17.md
+++ b/docs/MVP implementation plan/stage 17.md
@@ -178,7 +178,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Technical details:**
 - File: `web/app/search/page.tsx`
-  - On server, check session; if anon, do not call `listRealCollabs`; conditionally render a login-required card for the collaborations section/tab.
+  - On tab switch to Collaborations: if anon, immediately show a login‑required card and skip `listRealCollabs` (no API call needed). If authed, clear the projects placeholder so the copy reads “Search for Collaborations”.
   - If the page currently renders a unified view, guard the collab half only.
 
 **Files:**
@@ -186,7 +186,7 @@ Add/adjust tests for RLS, redirects, API 401s, and UI visibility. Update docs an
 
 **Tests:** Add a render test verifying no collab fetch for anon and that a login-required message is shown.
 
-**Status:** Not Started
+**Status:** Completed
 
 ---
 

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -307,6 +307,7 @@ Profile avatars (Step 6a)
 - Stage 17 — Collaboration visibility (auth-only) — In Progress
   - Tasks: gate `/collaborations` and `/collaborations/[id]` behind authentication; anonymous users see a friendly login-required screen on `/collaborations`; navbar still links to the page; enforce RLS to deny `select` on collaboration tables for anon; update tests and docs accordingly.
   - Status: RLS updated (auth-only selects) with tests; server list/get require session; API routes return 401 for anon; `/collaborations` renders a login-required screen for anon; navbar shows link to page. Next: consider gating `[id]` page similarly and adjust sitemap/search if needed.
+  - Update: `/collaborations/[id]` now also renders a login‑required screen for anon; `/search` immediately shows a login‑required card and skips API calls when switching to Collaborations while anonymous.
   - Done when: non-logged-in users cannot view collaboration lists or details (server and client enforced); logged-in users retain normal access.
 
 - Stage 18 — QA, docs, deploy — Planned

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -304,8 +304,9 @@ Profile avatars (Step 6a)
     - Analytics: include `search_mode` (role|project) and `role` when applicable in `search_performed` and `filter_apply`.
   - Done when: role search and split view work with correct ranking; closed posts excluded from role results; form uses combobox with duplicate prevention; indexes present; docs/tests updated.
 
-- Stage 17 — Collaboration visibility (auth-only) — Planned
+- Stage 17 — Collaboration visibility (auth-only) — In Progress
   - Tasks: gate `/collaborations` and `/collaborations/[id]` behind authentication; anonymous users are redirected to sign-in or see a friendly login-required screen; update navbar/links to hide collaboration entry points for non-auth users; enforce RLS to deny `select` on collaboration tables for anon; update tests and docs accordingly.
+  - Status: RLS updated — collaborations and related tables now require auth for `select` (migration added; policies restructured). Tests added to assert RLS. Next: server/API/page gating.
   - Done when: non-logged-in users cannot view collaboration lists or details (server and client enforced); logged-in users retain normal access.
 
 - Stage 18 — QA, docs, deploy — Planned

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -305,8 +305,8 @@ Profile avatars (Step 6a)
   - Done when: role search and split view work with correct ranking; closed posts excluded from role results; form uses combobox with duplicate prevention; indexes present; docs/tests updated.
 
 - Stage 17 — Collaboration visibility (auth-only) — In Progress
-  - Tasks: gate `/collaborations` and `/collaborations/[id]` behind authentication; anonymous users are redirected to sign-in or see a friendly login-required screen; update navbar/links to hide collaboration entry points for non-auth users; enforce RLS to deny `select` on collaboration tables for anon; update tests and docs accordingly.
-  - Status: RLS updated — collaborations and related tables now require auth for `select` (migration added; policies restructured). Tests added to assert RLS. Next: server/API/page gating.
+  - Tasks: gate `/collaborations` and `/collaborations/[id]` behind authentication; anonymous users see a friendly login-required screen on `/collaborations`; navbar still links to the page; enforce RLS to deny `select` on collaboration tables for anon; update tests and docs accordingly.
+  - Status: RLS updated (auth-only selects) with tests; server list/get require session; API routes return 401 for anon; `/collaborations` renders a login-required screen for anon; navbar shows link to page. Next: consider gating `[id]` page similarly and adjust sitemap/search if needed.
   - Done when: non-logged-in users cannot view collaboration lists or details (server and client enforced); logged-in users retain normal access.
 
 - Stage 18 — QA, docs, deploy — Planned

--- a/docs/MVP_TECH_SPEC.md
+++ b/docs/MVP_TECH_SPEC.md
@@ -307,7 +307,7 @@ Profile avatars (Step 6a)
 - Stage 17 — Collaboration visibility (auth-only) — In Progress
   - Tasks: gate `/collaborations` and `/collaborations/[id]` behind authentication; anonymous users see a friendly login-required screen on `/collaborations`; navbar still links to the page; enforce RLS to deny `select` on collaboration tables for anon; update tests and docs accordingly.
   - Status: RLS updated (auth-only selects) with tests; server list/get require session; API routes return 401 for anon; `/collaborations` renders a login-required screen for anon; navbar shows link to page. Next: consider gating `[id]` page similarly and adjust sitemap/search if needed.
-  - Update: `/collaborations/[id]` now also renders a login‑required screen for anon; `/search` immediately shows a login‑required card and skips API calls when switching to Collaborations while anonymous.
+  - Update: `/collaborations/[id]` now also renders a login‑required screen for anon; `/search` immediately shows a login‑required card and skips API calls when switching to Collaborations while anonymous; sitemap excludes collaborations.
   - Done when: non-logged-in users cannot view collaboration lists or details (server and client enforced); logged-in users retain normal access.
 
 - Stage 18 — QA, docs, deploy — Planned

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -57,6 +57,7 @@ Collaborations
   - Empty or absent filters are ignored. Tag filters are AND across types, OR within a type. `stages?` is an array (OR inside stage facet).
 - getCollab(id): `-> { collaboration, tags, owner, upvoteCount, hasUserUpvoted, comments }`
   - Auth-only (Stage 17): Requires an authenticated server session. Anonymous requests receive 401 at API routes; DB RLS denies anonymous selects.
+  - UI note: When anonymous users visit `/collaborations`, the page renders a login-required screen instead of calling this API.
 - updateCollab(id, fields): owner-only, fields optional: `{ title?, affiliatedOrg?, description?, stage?, lookingFor?, contact?, remarks?, isHiring? } -> { ok: true } | validation_error`
 - deleteCollab(id): owner-only `-> { ok: true }`
 - toggleCollabUpvote(collaborationId): `-> { ok: true, upvoted: boolean } | { error: 'unauthorized'|'rate_limited' }`

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -53,6 +53,7 @@ Collaborations
   - Rate limit: 5 per day per user (`collab_create` action, 24-hour window)
 - listCollabs(params): `{ cursor?, limit=20, q?, techTagIds?, categoryTagIds?, stages?, projectTypes?, mode?, role? } -> { items[], nextCursor? }` (defaults to `is_hiring=true`).
   - Auth-only (Stage 17): Requires an authenticated server session. Anonymous requests receive 401 at API routes; DB RLS denies anonymous selects.
+  - UI note: On `/search`, switching to Collaborations while anonymous shows a login-required card and skips the API call.
   - Each item exposes `collaboration.logoUrl` (derived) and `collaboration.logoPath` (storage key). `logoUrl` is a public URL built from `logoPath`.
   - Empty or absent filters are ignored. Tag filters are AND across types, OR within a type. `stages?` is an array (OR inside stage facet).
 - getCollab(id): `-> { collaboration, tags, owner, upvoteCount, hasUserUpvoted, comments }`

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -52,9 +52,11 @@ Collaborations
 - createCollab(input): `{ title≤160, affiliatedOrg?, projectTypes[], description 1–4000, stage, lookingFor[1..5]{ role, amount(1..99), prerequisite≤400, goodToHave≤400, description≤1200 }, contact≤200, remarks≤1000, techTagIds[], categoryTagIds[], logoPath? } -> { id } | validation_error`
   - Rate limit: 5 per day per user (`collab_create` action, 24-hour window)
 - listCollabs(params): `{ cursor?, limit=20, q?, techTagIds?, categoryTagIds?, stages?, projectTypes?, mode?, role? } -> { items[], nextCursor? }` (defaults to `is_hiring=true`).
+  - Auth-only (Stage 17): Requires an authenticated server session. Anonymous requests receive 401 at API routes; DB RLS denies anonymous selects.
   - Each item exposes `collaboration.logoUrl` (derived) and `collaboration.logoPath` (storage key). `logoUrl` is a public URL built from `logoPath`.
   - Empty or absent filters are ignored. Tag filters are AND across types, OR within a type. `stages?` is an array (OR inside stage facet).
 - getCollab(id): `-> { collaboration, tags, owner, upvoteCount, hasUserUpvoted, comments }`
+  - Auth-only (Stage 17): Requires an authenticated server session. Anonymous requests receive 401 at API routes; DB RLS denies anonymous selects.
 - updateCollab(id, fields): owner-only, fields optional: `{ title?, affiliatedOrg?, description?, stage?, lookingFor?, contact?, remarks?, isHiring? } -> { ok: true } | validation_error`
 - deleteCollab(id): owner-only `-> { ok: true }`
 - toggleCollabUpvote(collaborationId): `-> { ok: true, upvoted: boolean } | { error: 'unauthorized'|'rate_limited' }`

--- a/docs/SERVER_ACTIONS.md
+++ b/docs/SERVER_ACTIONS.md
@@ -58,7 +58,7 @@ Collaborations
   - Empty or absent filters are ignored. Tag filters are AND across types, OR within a type. `stages?` is an array (OR inside stage facet).
 - getCollab(id): `-> { collaboration, tags, owner, upvoteCount, hasUserUpvoted, comments }`
   - Auth-only (Stage 17): Requires an authenticated server session. Anonymous requests receive 401 at API routes; DB RLS denies anonymous selects.
-  - UI note: When anonymous users visit `/collaborations`, the page renders a login-required screen instead of calling this API.
+  - UI note: When anonymous users visit `/collaborations` or `/collaborations/[id]`, the page renders a login-required screen instead of calling this API.
 - updateCollab(id, fields): owner-only, fields optional: `{ title?, affiliatedOrg?, description?, stage?, lookingFor?, contact?, remarks?, isHiring? } -> { ok: true } | validation_error`
 - deleteCollab(id): owner-only `-> { ok: true }`
 - toggleCollabUpvote(collaborationId): `-> { ok: true, upvoted: boolean } | { error: 'unauthorized'|'rate_limited' }`

--- a/supabase/migrations/20250924145702_collaborations_auth_only_select.sql
+++ b/supabase/migrations/20250924145702_collaborations_auth_only_select.sql
@@ -1,0 +1,41 @@
+-- Stage 17: Collaboration visibility (auth-only)
+-- Require authentication for SELECT on collaboration tables
+
+-- Collaborations: select only when authenticated and not soft-deleted
+alter table if exists collaborations enable row level security;
+drop policy if exists collab_select_all on collaborations;
+create policy collab_select_all on collaborations for select using (
+  soft_deleted = false and auth.uid() is not null
+);
+
+-- Collaboration Tags (join table): select only when authenticated
+alter table if exists collaboration_tags enable row level security;
+drop policy if exists collaboration_tags_select_all on collaboration_tags;
+create policy collaboration_tags_select_all on collaboration_tags for select using (
+  auth.uid() is not null
+);
+
+-- Collaboration Upvotes: select only when authenticated
+alter table if exists collaboration_upvotes enable row level security;
+drop policy if exists collab_upvotes_select_all on collaboration_upvotes;
+create policy collab_upvotes_select_all on collaboration_upvotes for select using (
+  auth.uid() is not null
+);
+
+-- Collaboration Comments: select only when authenticated and not soft-deleted
+alter table if exists collab_comments enable row level security;
+drop policy if exists collab_comments_select_all on collab_comments;
+create policy collab_comments_select_all on collab_comments for select using (
+  soft_deleted = false and auth.uid() is not null
+);
+
+-- Collaboration Roles (role index for search): select only when authenticated
+alter table if exists collaboration_roles enable row level security;
+drop policy if exists collaboration_roles_select_all on collaboration_roles;
+create policy collaboration_roles_select_all on collaboration_roles for select using (
+  auth.uid() is not null
+);
+
+-- Roles Catalog remains public select (no change here)
+
+

--- a/supabase/schema.md
+++ b/supabase/schema.md
@@ -48,8 +48,8 @@ Notes (Stage 3 Profiles)
 - projects: select soft_deleted=false; insert/update/delete only owner
 - comments: select soft_deleted=false; insert only author; delete only author
 - project_upvotes: select all; insert/delete only same user
-- collaborations: select soft_deleted=false AND auth required; insert/update/delete only owner; `is_hiring` controls default list visibility
- - collaboration_roles: auth-only select; insert/delete only by collaboration owner (enforced via join to collaborations)
+- collaborations: select soft_deleted=false AND auth required (Stage 17); insert/update/delete only owner; `is_hiring` controls default list visibility
+ - collaboration_roles: auth-only select (Stage 17); insert/delete only by collaboration owner (enforced via join to collaborations)
  - roles_catalog: public select (curated read-only)
 
 Notes (Stage 15 Logos & Avatars)

--- a/supabase/schema.md
+++ b/supabase/schema.md
@@ -48,8 +48,8 @@ Notes (Stage 3 Profiles)
 - projects: select soft_deleted=false; insert/update/delete only owner
 - comments: select soft_deleted=false; insert only author; delete only author
 - project_upvotes: select all; insert/delete only same user
-- collaborations: select soft_deleted=false; insert/update/delete only owner; `is_hiring` controls default list visibility
- - collaboration_roles: public select; insert/delete only by collaboration owner (enforced via join to collaborations)
+- collaborations: select soft_deleted=false AND auth required; insert/update/delete only owner; `is_hiring` controls default list visibility
+ - collaboration_roles: auth-only select; insert/delete only by collaboration owner (enforced via join to collaborations)
  - roles_catalog: public select (curated read-only)
 
 Notes (Stage 15 Logos & Avatars)

--- a/web/app/api/collaborations/get/route.ts
+++ b/web/app/api/collaborations/get/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse } from "next/server"
 import { getCollab } from "@/lib/server/collabs"
+import { getServerSupabase } from "@/lib/supabaseServer"
 
 export async function GET(req: Request) {
+  // Stage 17: Auth-only. Require an authenticated session.
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 })
+  }
   const url = new URL(req.url)
   const id = url.searchParams.get("id")
   if (!id) return NextResponse.json({ error: "missing_id" }, { status: 400 })

--- a/web/app/api/collaborations/list/route.ts
+++ b/web/app/api/collaborations/list/route.ts
@@ -1,7 +1,14 @@
 import { NextResponse } from "next/server"
 import { listCollabs } from "@/lib/server/collabs"
+import { getServerSupabase } from "@/lib/supabaseServer"
 
 export async function GET(req: Request) {
+  // Stage 17: Auth-only. Require an authenticated session.
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) {
+    return NextResponse.json({ error: "unauthorized" }, { status: 401 })
+  }
   const { searchParams } = new URL(req.url)
   const limit = Number(searchParams.get("limit") || "20")
   const q = searchParams.get("q") || undefined

--- a/web/app/collaborations/[id]/page.tsx
+++ b/web/app/collaborations/[id]/page.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next"
 import { notFound } from "next/navigation"
+import Link from "next/link"
 import Image from "next/image"
 import { LogoImage } from "@/components/ui/logo-image"
 import { LogoChangeOverlay } from "@/components/ui/logo-change-overlay"
@@ -38,14 +39,24 @@ export async function generateMetadata({ params }: CollabDetailPageProps): Promi
 
 export default async function CollabDetailPage({ params }: CollabDetailPageProps) {
   const p = await params
+  // Stage 17: Gate detail page for anonymous users with a login-required screen
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  if (!auth.user) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Sign in to view this collaboration</h1>
+        <p className="text-gray-600 mb-8">Join the community to browse details and connect with teams.</p>
+        <Link href={`/auth/sign-in?redirectTo=/collaborations/${encodeURIComponent(p.id)}`} className="inline-flex items-center px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900">Sign in to view</Link>
+      </div>
+    )
+  }
   const item = await getCollab(p.id)
 
   if (!item) {
     notFound()
   }
 
-  const supabase = await getServerSupabase()
-  const { data: auth } = await supabase.auth.getUser()
   const isOwner = !!auth.user && auth.user.id === item.collaboration.ownerId
   const logoSrc = (item.collaboration as any).logoUrl || ""
 

--- a/web/app/collaborations/page.tsx
+++ b/web/app/collaborations/page.tsx
@@ -14,9 +14,9 @@ export default async function CollaborationsPage() {
   if (!auth.user) {
     return (
       <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
-        <h1 className="text-3xl font-bold text-gray-900 mb-4">Sign in to view collaborations</h1>
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Sign in to find collaborators</h1>
         <p className="text-gray-600 mb-8">Join the community to browse and post collaboration opportunities.</p>
-        <Link href="/auth/sign-in?redirectTo=/collaborations" className="inline-flex items-center px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900">Sign in</Link>
+        <Link href="/auth/sign-in?redirectTo=/collaborations" className="inline-flex items-center px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900">Sign in to find collaborators</Link>
       </div>
     )
   }

--- a/web/app/collaborations/page.tsx
+++ b/web/app/collaborations/page.tsx
@@ -1,11 +1,25 @@
 import CollaborationsClient from "./CollaborationsClient"
 import { Suspense } from "react"
+import { getServerSupabase } from "@/lib/supabaseServer"
+import Link from "next/link"
 
 interface PageProps {
   searchParams: Promise<Record<string, string | string[] | undefined>>
 }
 
-export default function CollaborationsPage() {
+export default async function CollaborationsPage() {
+  const supabase = await getServerSupabase()
+  const { data: auth } = await supabase.auth.getUser()
+  // If not signed-in, show a friendly login-required screen instead of redirect
+  if (!auth.user) {
+    return (
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 lg:px-8 py-16 text-center">
+        <h1 className="text-3xl font-bold text-gray-900 mb-4">Sign in to view collaborations</h1>
+        <p className="text-gray-600 mb-8">Join the community to browse and post collaboration opportunities.</p>
+        <Link href="/auth/sign-in?redirectTo=/collaborations" className="inline-flex items-center px-4 py-2 rounded-md bg-black text-white hover:bg-gray-900">Sign in</Link>
+      </div>
+    )
+  }
   return (
     <Suspense>
       <CollaborationsClient />

--- a/web/app/sitemap.xml/route.ts
+++ b/web/app/sitemap.xml/route.ts
@@ -1,28 +1,21 @@
 import { NextResponse } from "next/server"
 import { listProjects } from "@/lib/server/projects"
-import { listCollabs } from "@/lib/server/collabs"
+// Stage 17: Collaborations are auth-only. Exclude collaboration pages from public sitemap.
 
 export async function GET() {
   const base = "https://builders.pub"
   const urls: Array<{ loc: string; lastmod?: string; priority?: number }> = [
     { loc: `${base}/` },
     { loc: `${base}/projects` },
-    { loc: `${base}/collaborations` },
     { loc: `${base}/search` },
   ]
 
   try {
-    const [{ items: projects }, { items: collabs }] = await Promise.all([
-      listProjects({ limit: 50, sort: "recent" }).catch(() => ({ items: [] as any[] })),
-      listCollabs({ limit: 50 }).catch(() => ({ items: [] as any[] })),
-    ])
+    const { items: projects } = await listProjects({ limit: 50, sort: "recent" }).catch(() => ({ items: [] as any[] }))
     for (const p of projects) {
       urls.push({ loc: `${base}/projects/${p.project.id}`, lastmod: p.project.createdAt.toISOString(), priority: 0.8 })
     }
-    for (const c of collabs) {
-      const createdAt = (c.collaboration.createdAt as any)?.toISOString?.() || new Date(c.collaboration.createdAt as any).toISOString()
-      urls.push({ loc: `${base}/collaborations/${c.collaboration.id}`, lastmod: createdAt, priority: 0.7 })
-    }
+    // Note: collaboration pages are intentionally excluded from sitemap
   } catch {}
 
   const body = `<?xml version="1.0" encoding="UTF-8"?>\n` +

--- a/web/tests/collaborations.split-view.client.test.tsx
+++ b/web/tests/collaborations.split-view.client.test.tsx
@@ -22,7 +22,7 @@ vi.mock("@/lib/api/collabs", () => ({
 vi.stubGlobal("fetch", vi.fn(async (url: string) => {
   const u = new URL(url, "http://localhost")
   if (u.pathname === "/api/collaborations/get" && u.searchParams.get("id") === "c2") {
-    return { ok: true, json: async () => ({ item: { collaboration: { id: "c2", title: "Beta", description: "Detail", lookingFor: [{ role: "AI Engineer" }] }, owner: { displayName: "B" } } }) } as any
+    return { ok: true, json: async () => ({ item: { collaboration: { id: "c2", title: "Beta", description: "Detail", createdAt: new Date().toISOString(), lookingFor: [{ role: "AI Engineer" }] }, owner: { displayName: "B" }, tags: { technology: [], category: [] }, upvoteCount: 0 } }) } as any
   }
   return { ok: false, json: async () => ({}) } as any
 }) as any)

--- a/web/tests/collabs.api.test.ts
+++ b/web/tests/collabs.api.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from "vitest"
+import { describe, it, expect, vi, beforeEach } from "vitest"
 
 const mockItems = [
   {
@@ -14,6 +14,13 @@ vi.mock("@/lib/server/collabs", () => ({
 }))
 
 describe("/api/collaborations/list", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    // Default: authenticated user for non-401 tests
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) } })),
+    }))
+  })
   it("responds with items and nextCursor", async () => {
     const { GET } = await import("@/app/api/collaborations/list/route")
     const req = new Request("http://localhost/api/collaborations/list?q=ai&limit=2&stages=mvp_development")
@@ -21,6 +28,46 @@ describe("/api/collaborations/list", () => {
     const json = await (res as any).json()
     expect(json).toHaveProperty("items")
     expect(Array.isArray(json.items)).toBe(true)
+  })
+
+  it("returns 401 when anonymous (Stage 17)", async () => {
+    // Mock getServerSupabase to return no user
+    vi.resetModules()
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: null } }) } })),
+    }))
+    const { GET } = await import("@/app/api/collaborations/list/route")
+    const req = new Request("http://localhost/api/collaborations/list")
+    const res = await GET(req as any)
+    expect(res.status).toBe(401)
+  })
+})
+
+describe("/api/collaborations/get", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) } })),
+    }))
+    // Mocked collab detail response via server module is not needed here; route will call server getCollab under auth
+    vi.doMock("@/lib/server/collabs", () => ({
+      getCollab: vi.fn(async () => ({
+        collaboration: { id: "c1", ownerId: "u1", title: "T", description: "d", createdAt: new Date(), isHiring: true, lookingFor: [] },
+        tags: { technology: [], category: [] },
+        upvoteCount: 0,
+        owner: { userId: "u1", displayName: "User" },
+      })),
+    }))
+  })
+  it("returns 401 when anonymous (Stage 17)", async () => {
+    vi.resetModules()
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: null } }) } })),
+    }))
+    const { GET } = await import("@/app/api/collaborations/get/route")
+    const req = new Request("http://localhost/api/collaborations/get?id=c1")
+    const res = await GET(req as any)
+    expect(res.status).toBe(401)
   })
 })
 

--- a/web/tests/rls.collaborations.auth-only.test.ts
+++ b/web/tests/rls.collaborations.auth-only.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest"
+import { readFile } from "node:fs/promises"
+import path from "node:path"
+
+describe("RLS policies enforce auth-only selects for collaboration tables", () => {
+  it("contains auth.uid() is not null for select on collaborations and related tables", async () => {
+    const rlsPath = path.resolve(process.cwd(), "..", "supabase", "rls_policies.sql")
+    const sql = await readFile(rlsPath, "utf8")
+
+    const checks: Array<{ table: string; policyName: RegExp }> = [
+      { table: "collaborations", policyName: /collab_select_all/ },
+      { table: "collaboration_tags", policyName: /collaboration_tags_select_all/ },
+      { table: "collaboration_upvotes", policyName: /collab_upvotes_select_all/ },
+      { table: "collab_comments", policyName: /collab_comments_select_all/ },
+      { table: "collaboration_roles", policyName: /collaboration_roles_select_all/ },
+    ]
+
+    for (const { table, policyName } of checks) {
+      const tableBlock = new RegExp(
+        String.raw`(?s)alter table.*?${table}.*?create policy\s+${policyName.source}.*?for select using \((.*?)\);`,
+        "i"
+      )
+      const match = sql.match(tableBlock)
+      expect(match, `missing select policy for ${table}`).toBeTruthy()
+      const usingClause = match?.[1] || ""
+      expect(/auth\.uid\(\)\s+is\s+not\s+null/i.test(usingClause), `auth guard missing for ${table}`).toBe(true)
+      // For collaborations and collab_comments, also assert soft_deleted=false is preserved
+      if (table === "collaborations" || table === "collab_comments") {
+        expect(/soft_deleted\s*=\s*false/i.test(usingClause), `soft_deleted=false missing for ${table}`).toBe(true)
+      }
+    }
+  })
+})
+
+

--- a/web/tests/routes.collaborations.detail.auth.test.tsx
+++ b/web/tests/routes.collaborations.detail.auth.test.tsx
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as React from "react"
+import { renderToString } from "react-dom/server"
+
+describe("/collaborations/[id] auth gating", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it("renders login-required screen for anonymous users", async () => {
+    // Ensure React is available globally for server-side JSX rendering in tests
+    // @ts-expect-error test setup
+    (global as any).React = React
+    // Stub client-side modules to avoid pulling env-dependent imports
+    vi.doMock("@/lib/api/auth", () => ({ useAuth: () => ({ isAuthenticated: false }) }))
+    vi.doMock("@/lib/supabaseClient", () => ({ supabase: {} }))
+    vi.doMock("@/components/features/collaborations/collab-upvote-button", () => ({ CollabUpvoteButton: () => null }))
+    vi.doMock("@/components/features/collaborations/collab-comment-form", () => ({ CollabCommentForm: () => null }))
+    vi.doMock("@/components/features/collaborations/collab-comment-list", () => ({ CollabCommentList: () => null }))
+    vi.doMock("@/components/features/collaborations/hiring-toggle", () => ({ HiringToggle: () => null }))
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: null } }) } })),
+    }))
+    const mod = await import("@/app/collaborations/[id]/page")
+    const Page = mod.default as (props: { params: { id: string } }) => Promise<JSX.Element>
+    const el = await Page({ params: { id: "c1" } })
+    const html = renderToString(el)
+    expect(html).toContain("Sign in to view this collaboration")
+    expect(html).toContain("Sign in to view")
+  })
+
+  it("renders detail for authenticated users", async () => {
+    // @ts-expect-error test setup
+    (global as any).React = React
+    // Stub client-side modules
+    vi.doMock("@/lib/api/auth", () => ({ useAuth: () => ({ isAuthenticated: true, user: { id: "u1" } }) }))
+    vi.doMock("@/lib/supabaseClient", () => ({ supabase: {} }))
+    vi.doMock("@/components/features/collaborations/collab-upvote-button", () => ({ CollabUpvoteButton: () => null }))
+    vi.doMock("@/components/features/collaborations/collab-comment-form", () => ({ CollabCommentForm: () => null }))
+    vi.doMock("@/components/features/collaborations/collab-comment-list", () => ({ CollabCommentList: () => null }))
+    vi.doMock("@/components/features/collaborations/hiring-toggle", () => ({ HiringToggle: () => null }))
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) } })),
+    }))
+    vi.doMock("@/lib/server/collabs", () => ({
+      getCollab: vi.fn(async () => ({
+        collaboration: { id: "c1", ownerId: "u1", title: "Alpha", description: "desc", createdAt: new Date(), lookingFor: [] },
+        tags: { technology: [], category: [] },
+        upvoteCount: 0,
+        owner: { userId: "u1", displayName: "User" },
+      })),
+    }))
+    const mod = await import("@/app/collaborations/[id]/page")
+    const Page = mod.default as (props: { params: { id: string } }) => Promise<JSX.Element>
+    const el = await Page({ params: { id: "c1" } })
+    const html = renderToString(el)
+    expect(html).toContain("Alpha")
+    expect(html).toContain("Project Description")
+  })
+})
+
+

--- a/web/tests/routes.collaborations.list.auth.test.tsx
+++ b/web/tests/routes.collaborations.list.auth.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest"
+import * as React from "react"
+import { renderToString } from "react-dom/server"
+
+describe("/collaborations list page auth gating", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+  })
+
+  it("renders login-required screen for anonymous users", async () => {
+    // Ensure React is available globally for server-side JSX rendering in tests
+    // @ts-expect-error test setup
+    ;(global as any).React = React
+
+    // Mock server session as anonymous
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: null } }) } })),
+    }))
+
+    // Mock client to ensure it is NOT rendered for anon
+    const clientSpy = vi.fn(() => null)
+    vi.doMock("@/app/collaborations/CollaborationsClient", () => ({ default: clientSpy }))
+
+    const mod = await import("@/app/collaborations/page")
+    const Page = mod.default as () => Promise<JSX.Element>
+    const el = await Page()
+    const html = renderToString(el)
+
+    expect(html).toContain("Sign in to find collaborators")
+    expect(html).toContain("/auth/sign-in?redirectTo=/collaborations")
+    expect(clientSpy).not.toHaveBeenCalled()
+  })
+
+  it("renders list client for authenticated users", async () => {
+    // @ts-expect-error test setup
+    ;(global as any).React = React
+
+    // Mock server session as authenticated
+    vi.doMock("@/lib/supabaseServer", () => ({
+      getServerSupabase: vi.fn(async () => ({ auth: { getUser: async () => ({ data: { user: { id: "u1" } } }) } })),
+    }))
+
+    // Mock client component to confirm invocation
+    const clientSpy = vi.fn(() => React.createElement("div", null, "CLIENT"))
+    vi.doMock("@/app/collaborations/CollaborationsClient", () => ({ default: clientSpy }))
+
+    const mod = await import("@/app/collaborations/page")
+    const Page = mod.default as () => Promise<JSX.Element>
+    const el = await Page()
+    const html = renderToString(el)
+
+    expect(clientSpy).toHaveBeenCalledTimes(1)
+    expect(html).toContain("CLIENT")
+  })
+})
+
+

--- a/web/tests/search.collabs.auth-gating.test.tsx
+++ b/web/tests/search.collabs.auth-gating.test.tsx
@@ -1,0 +1,126 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest"
+import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react"
+import React from "react"
+
+// Router/search params mocks with mutable state
+const searchParamsMock: { current: URLSearchParams } = { current: new URLSearchParams("") }
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => searchParamsMock.current,
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+}))
+
+// Avoid remote tags fetch in FilterBar/useTags
+vi.mock("@/hooks/useTags", () => ({
+  useTags: () => ({ technology: [], category: [], loading: false, error: null }),
+}))
+
+// UI primitives simplified
+vi.mock("@/components/ui/input", () => ({
+  Input: ({ value, onChange, placeholder, className, type = "text" }: any) => (
+    <input type={type} value={value} onChange={onChange} placeholder={placeholder} className={className} />
+  ),
+}))
+vi.mock("@/components/ui/button", () => ({
+  Button: ({ children, onClick, type = "button", disabled, variant, className, ...rest }: any) => (
+    <button onClick={onClick} type={type} disabled={disabled} className={className} data-variant={variant} {...rest}>
+      {children}
+    </button>
+  ),
+}))
+vi.mock("@/components/ui/empty-state", () => ({
+  EmptyState: ({ title, description, action }: any) => (
+    <div>
+      <h3>{title}</h3>
+      {description ? <p>{description}</p> : null}
+      {action}
+    </div>
+  ),
+}))
+vi.mock("next/link", () => ({ default: ({ href, children }: any) => <a href={href}>{children}</a> }))
+
+// Spy on API calls
+const listCollabsSpy = vi.fn()
+vi.mock("@/lib/api/collabs", () => ({
+  listCollabs: (...args: any[]) => listCollabsSpy(...args),
+}))
+const listProjectsSpy = vi.fn(async () => ({ items: [] }))
+vi.mock("@/lib/api/projects", () => ({
+  listProjects: (...args: any[]) => listProjectsSpy(...args),
+}))
+
+describe("/search collaborations tab gating", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    // Ensure React is globally available for JSX runtime in this environment
+    // @ts-expect-error test setup
+    ;(global as any).React = React
+    // Reset search params to default
+    searchParamsMock.current = new URLSearchParams("")
+    // Default API spy return values
+    listCollabsSpy.mockResolvedValue({ items: [], nextCursor: undefined })
+  })
+
+  afterEach(() => {
+    cleanup()
+  })
+
+  it("anonymous: switching to Collaborations shows login-required and does NOT call collab API", async () => {
+    vi.doMock("@/lib/api/auth", () => ({ useAuth: () => ({ isAuthenticated: false }) }))
+    const mod = await import("@/app/search/page")
+    const Page = mod.default
+    render(<Page />)
+
+    // Start on projects tab; switch to collaborations
+    const collabTab = screen.getByRole("button", { name: /collaborations/i })
+    fireEvent.click(collabTab)
+
+    // Should show login-required empty state
+    await screen.findByRole("heading", { name: /sign in to search collaborations/i })
+
+    // Placeholder changes for anon is the login-required state; ensure API not called
+    expect(listCollabsSpy).not.toHaveBeenCalled()
+
+    // Verify CTA link targets sign-in with redirect to collabs search
+    const link = screen.getByRole("link", { name: /sign in to search collaborators/i })
+    expect(link.getAttribute("href")).toContain("/auth/sign-in?redirectTo=/search?type=collabs")
+  })
+
+  it("authenticated: switching to Collaborations updates placeholder and triggers API on search", async () => {
+    vi.doMock("@/lib/api/auth", () => ({ useAuth: () => ({ isAuthenticated: true }) }))
+    const mod = await import("@/app/search/page")
+    const Page = mod.default
+    render(<Page />)
+
+    // Switch to collaborations tab
+    const collabTab = screen.getByRole("button", { name: /collaborations/i })
+    fireEvent.click(collabTab)
+
+    // Placeholder should reflect collaborations context
+    const input = screen.getByRole("searchbox") as HTMLInputElement
+    expect(input.placeholder.toLowerCase()).toContain("collaborations")
+
+    // Perform explicit search
+    const searchBtn = screen.getByRole("button", { name: /^Search$/i })
+    fireEvent.click(searchBtn)
+
+    // API should be called (listCollabs) after submit
+    await waitFor(() => expect(listCollabsSpy).toHaveBeenCalled())
+  })
+
+  it("anonymous: direct load /search?type=collabs shows login-required and no API call", async () => {
+    vi.doMock("@/lib/api/auth", () => ({ useAuth: () => ({ isAuthenticated: false }) }))
+    // Override search params to include type=collabs
+    searchParamsMock.current = new URLSearchParams("type=collabs")
+
+    const mod = await import("@/app/search/page")
+    const Page = mod.default
+    render(<Page />)
+
+    await screen.findByRole("heading", { name: /sign in to search collaborations/i })
+    expect(listCollabsSpy).not.toHaveBeenCalled()
+  })
+})
+
+

--- a/web/tests/sitemap.test.ts
+++ b/web/tests/sitemap.test.ts
@@ -3,9 +3,7 @@ import { describe, it, expect, vi } from "vitest"
 vi.mock("@/lib/server/projects", () => ({
   listProjects: vi.fn(async () => ({ items: [{ project: { id: "p1", createdAt: new Date() } }] })),
 }))
-vi.mock("@/lib/server/collabs", () => ({
-  listCollabs: vi.fn(async () => ({ items: [{ collaboration: { id: "c1", createdAt: new Date() } }] })),
-}))
+// Collaborations are auth-only and excluded from sitemap in Stage 17
 
 describe("sitemap.xml route", () => {
   it("includes core pages and items", async () => {
@@ -14,10 +12,8 @@ describe("sitemap.xml route", () => {
     const xml = await (res as any).text()
     expect(xml).toContain("<loc>https://builders.pub/</loc>")
     expect(xml).toContain("<loc>https://builders.pub/projects</loc>")
-    expect(xml).toContain("<loc>https://builders.pub/collaborations</loc>")
     expect(xml).toContain("<loc>https://builders.pub/search</loc>")
     expect(xml).toContain("/projects/p1")
-    expect(xml).toContain("/collaborations/c1")
   })
 })
 


### PR DESCRIPTION
## Summary

Stage 17 implements auth-only visibility for Collaboration features:
- Anonymous users cannot view collaboration lists or details.
- Clear login-required screens guide anonymous users.
- DB-level RLS enforces auth-only reads.
- Search and sitemap adjust to avoid exposing private content.

This PR completes Stage 17 with code, tests, and docs.

## Scope of Changes

- Database / RLS
  - Enforce auth-only SELECT on collaboration tables:
    - `collaborations` (also `soft_deleted=false`)
    - `collaboration_tags`
    - `collaboration_upvotes`
    - `collaboration_roles`
    - `collab_comments` (also `soft_deleted=false`)
    - `roles_catalog` remains public SELECT
  - Updated canonical `supabase/rls_policies.sql` (reordered with concise sections).
  - Migration present to enforce policies (see repo migrations).

- Server (auth-only reads)
  - `web/lib/server/collabs.ts`: `listCollabs`/`getCollab` now require `getServerSupabase().auth.getUser()`; anonymous requests short-circuit (no DB read).

- API routes
  - `web/app/api/collaborations/list/route.ts`: 401 for anonymous.
  - `web/app/api/collaborations/get/route.ts`: 401 for anonymous.

- Route gating (App Router)
  - `web/app/collaborations/page.tsx`: login-required screen for anonymous users (“Sign in to find collaborators”).
  - `web/app/collaborations/[id]/page.tsx`: login-required screen for anonymous users (“Sign in to view this collaboration”).
  - Navbar continues to show the Collaborations link; gating handled at page level.

- Landing page
  - `web/app/page.tsx`: skips collaboration preview fetch for anonymous users; shows compact sign‑in CTA.

- Search page
  - `web/app/search/page.tsx`:
    - Switching to “Collaborations” tab while anonymous immediately shows login-required card and DOES NOT call the collab API.
    - Placeholder text updates to collaborations context when authenticated.

- Sitemap
  - `web/app/sitemap.xml/route.ts`: removes collaboration URLs.
  - Tests updated accordingly.

- Tests (added/updated)
  - Auth gating: 
    - `web/tests/routes.collaborations.detail.auth.test.tsx` (existing)
    - NEW `web/tests/routes.collaborations.list.auth.test.tsx`
  - Search tab gating:
    - NEW `web/tests/search.collabs.auth-gating.test.tsx`
  - API 401s: `web/tests/collabs.api.test.ts` (updated)
  - RLS presence: `web/tests/rls.collaborations.auth-only.test.ts`
  - Sitemap exclusion: `web/tests/sitemap.test.ts` (updated)

- Documentation
  - `docs/AUTH.md`: auth-only reads and gating behavior documented.
  - `docs/SERVER_ACTIONS.md`: `listCollabs`/`getCollab` require auth; UI notes for anon.
  - `docs/MVP_TECH_SPEC.md`: Stage 17 updates incl. sitemap exclusion.
  - `supabase/schema.md`: RLS summary updated for auth-only collaborations.
  - `CHANGELOG.md`: Unreleased entry for auth-only collaborations (UI/API/RLS/SEO).
  - `docs/MVP implementation plan/stage 17.md`: plan, progress, and acceptance criteria finalized; clarified “login-required screen” (not redirect).

## How to Run

```bash
# From repo root
pnpm -C web build
pnpm -C web test --run
pnpm -C web dev -p 3002
```

- Visit `/collaborations`:
  - Anonymous: “Sign in to find collaborators” + button → `/auth/sign-in?redirectTo=/collaborations`
  - Authenticated: list renders normally
- Visit `/collaborations/<id>`:
  - Anonymous: “Sign in to view this collaboration”
  - Authenticated: detail renders (or Not Found if missing/soft-deleted)
- Visit `/search`:
  - Switch to “Collaborations” while anonymous: login-required card shown immediately; no call to `/api/collaborations/list`
  - Authenticated: placeholder changes to “Search collaborations…”; search triggers collab API
- Open `/sitemap.xml`: no `/collaborations` or `/collaborations/<id>` URLs

## Acceptance Checks

- Auth-only access
  - Anonymous users see login-required screens on `/collaborations` and `/collaborations/[id]`.
  - Anonymous API requests to `/api/collaborations/list` and `/get` return 401.
  - DB RLS denies SELECT on collaboration tables for anonymous sessions.
- UI behavior
  - Navbar shows “Collaborations”; gating handled on the page.
  - Landing does not fetch or render collaboration previews for anonymous users; shows sign-in CTA.
  - Search tab “Collaborations” for anonymous shows login-required card and makes no API call.
- SEO
  - Sitemap excludes all collaboration routes.
- Quality
  - All tests pass; build is green.

## Notes / Limitations

- `roles_catalog` remains public SELECT (curated read-only).
- This stage focuses on visibility and gating. Further role-specific UX or broader redirects are out of scope.

## Related Docs

- `docs/AUTH.md`
- `docs/SERVER_ACTIONS.md`
- `docs/MVP_TECH_SPEC.md` (Stage 17)
- `supabase/schema.md`, `supabase/rls_policies.sql`
- `docs/MVP implementation plan/stage 17.md`

## Changelog

- `CHANGELOG.md` updated under `## [Unreleased]` to reflect auth-only collaborations and related UI/API/SEO changes.

## Branch / Merge

- Branch: `feat/stage-17-auth-only-collabs`
- Base: `main`
- Merge strategy: Squash and merge (per docs), then delete branch.